### PR TITLE
Add Resources layer with procedural generation

### DIFF
--- a/config/resources.json
+++ b/config/resources.json
@@ -1,0 +1,9 @@
+[
+  {"id":1,"name":"Iron","color":"#b7410e","base":0.05,"type":"metal"},
+  {"id":2,"name":"Copper","color":"#b87333","base":0.04,"type":"metal"},
+  {"id":3,"name":"Gold","color":"#ffd700","base":0.01,"type":"metal"},
+  {"id":4,"name":"Coal","color":"#444","base":0.07,"type":"fuel"},
+  {"id":5,"name":"Oil","color":"#222","base":0.03,"type":"fuel"},
+  {"id":6,"name":"Mithril","color":"#8a8aff","base":0.005,"type":"magic"},
+  {"id":7,"name":"Mana Crystal","color":"#00ffff","base":0.005,"type":"magic"}
+]

--- a/index.html
+++ b/index.html
@@ -679,6 +679,14 @@
               Mar<u>k</u>ers
             </li>
             <li
+              id="toggleResources"
+              data-tip="Resources: click to toggle, drag to raise or lower the layer. Ctrl + click to edit layer style"
+              data-shortcut="Q"
+              onclick="toggleResources(event)"
+            >
+              Resources
+            </li>
+            <li
               id="toggleRulers"
               data-tip="Rulers: click to toggle, drag to move, click on label to delete. Ctrl + click to edit layer style"
               data-shortcut="= (equal sign)"
@@ -775,6 +783,7 @@
             <option value="landmass">Landmass</option>
             <option value="legend">Legend</option>
             <option value="markers">Markers</option>
+            <option value="resources">Resources</option>
             <option value="armies">Military</option>
             <option value="ocean">Ocean</option>
             <option value="population">Population</option>
@@ -8105,6 +8114,7 @@
     <script src="modules/religions-generator.js?v=1.106.0"></script>
     <script src="modules/military-generator.js?v=1.107.0"></script>
     <script src="modules/markers-generator.js?v=1.107.0"></script>
+    <script src="modules/resources-generator.js?v=1.0.0"></script>
     <script src="modules/zones-generator.js?v=1.106.0"></script>
     <script src="modules/coa-generator.js?v=1.99.00"></script>
     <script src="modules/resample.js?v=1.106.4"></script>
@@ -8172,6 +8182,7 @@
     <script defer src="modules/renderers/draw-borders.js?v=1.104.0"></script>
     <script defer src="modules/renderers/draw-heightmap.js?v=1.104.0"></script>
     <script defer src="modules/renderers/draw-markers.js?v=1.108.5"></script>
+    <script defer src="modules/renderers/draw-resources.js?v=1.0.0"></script>
     <script defer src="modules/renderers/draw-scalebar.js?v=1.108.1"></script>
     <script defer src="modules/renderers/draw-temperature.js?v=1.104.0"></script>
     <script defer src="modules/renderers/draw-emblems.js?v=1.104.0"></script>

--- a/main.js
+++ b/main.js
@@ -83,6 +83,7 @@ let burgIcons = icons.append("g").attr("id", "burgIcons");
 let anchors = icons.append("g").attr("id", "anchors");
 let armies = viewbox.append("g").attr("id", "armies");
 let markers = viewbox.append("g").attr("id", "markers");
+let resources = viewbox.append("g").attr("id", "resources");
 let fogging = viewbox
   .append("g")
   .attr("id", "fogging-cont")
@@ -663,6 +664,7 @@ async function generate(options) {
 
     Military.generate();
     Markers.generate();
+    await Resources.generate();
     Zones.generate();
 
     drawScaleBar(scaleBar, scale);

--- a/modules/io/load.js
+++ b/modules/io/load.js
@@ -351,6 +351,7 @@ async function parseLoadedData(data, mapVersion) {
       anchors = icons.select("#anchors");
       armies = viewbox.select("#armies");
       markers = viewbox.select("#markers");
+      resources = viewbox.select("#resources");
       ruler = viewbox.select("#ruler");
       fogging = viewbox.select("#fogging");
       debug = viewbox.select("#debug");
@@ -392,6 +393,7 @@ async function parseLoadedData(data, mapVersion) {
       pack.markers = data[35] ? JSON.parse(data[35]) : [];
       pack.routes = data[37] ? JSON.parse(data[37]) : [];
       pack.zones = data[38] ? JSON.parse(data[38]) : [];
+      pack.resources = data[39] ? JSON.parse(data[39]) : [];
       pack.cells.biome = Uint8Array.from(data[16].split(","));
       pack.cells.burg = Uint16Array.from(data[17].split(","));
       pack.cells.conf = Uint8Array.from(data[18].split(","));
@@ -456,6 +458,7 @@ async function parseLoadedData(data, mapVersion) {
       if (isVisible(icons)) turnOn("toggleBurgIcons");
       if (hasChildren(armies) && isVisible(armies)) turnOn("toggleMilitary");
       if (hasChildren(markers)) turnOn("toggleMarkers");
+      if (hasChildren(resources)) turnOn("toggleResources");
       if (isVisible(ruler)) turnOn("toggleRulers");
       if (isVisible(scaleBar)) turnOn("toggleScaleBar");
       if (isVisibleNode(byId("vignette"))) turnOn("toggleVignette");

--- a/modules/io/save.js
+++ b/modules/io/save.js
@@ -155,7 +155,8 @@ function prepareMapData() {
     markers,
     cellRoutes,
     routes,
-    zones
+    zones,
+    JSON.stringify(pack.resources)
   ].join("\r\n");
   return mapData;
 }

--- a/modules/renderers/draw-resources.js
+++ b/modules/renderers/draw-resources.js
@@ -1,0 +1,14 @@
+"use strict";
+
+function drawResources() {
+  TIME && console.time("drawResources");
+  resources.selectAll("*").remove();
+  const html = pack.resources.map(r => {
+    const type = Resources.getType(r.type);
+    const color = type?.color || "#000";
+    const size = 3;
+    return `<circle id="resource${r.i}" cx="${r.x}" cy="${r.y}" r="${size}" fill="${color}" />`;
+  });
+  resources.html(html.join(""));
+  TIME && console.timeEnd("drawResources");
+}

--- a/modules/resources-generator.js
+++ b/modules/resources-generator.js
@@ -1,0 +1,57 @@
+"use strict";
+
+window.Resources = (function () {
+  let types = [];
+
+  async function loadConfig() {
+    if (types.length) return types;
+    try {
+      types = await (await fetch("config/resources.json")).json();
+    } catch (e) {
+      console.error("Failed to load resources config", e);
+      types = [];
+    }
+    return types;
+  }
+
+  async function generate() {
+    await loadConfig();
+    const {cells} = pack;
+    pack.resources = [];
+    cells.resource = new Uint8Array(cells.i.length);
+    let id = 0;
+    for (const i of cells.i) {
+      if (cells.h[i] < 20) continue; // ignore water
+      const height = cells.h[i];
+      const biome = cells.biome[i];
+      const weights = types.map(t => {
+        let w = t.base || 0;
+        if (t.type === "metal" && height > 60) w *= 3;
+        if (t.type === "fuel" && height < 60 && [3,4,5,7,8,9,12].includes(biome)) w *= 2;
+        if (t.type === "magic" && height > 70) w *= 5;
+        return w;
+      });
+      const total = weights.reduce((a, b) => a + b, 0);
+      if (Math.random() >= total) continue;
+      let r = Math.random() * total;
+      let resIndex = -1;
+      for (let j = 0; j < weights.length; j++) {
+        r -= weights[j];
+        if (r <= 0) {
+          resIndex = j;
+          break;
+        }
+      }
+      if (resIndex === -1) continue;
+      const type = types[resIndex];
+      cells.resource[i] = type.id;
+      const [x, y] = cells.p[i];
+      pack.resources.push({i: ++id, type: type.id, x: rn(x, 2), y: rn(y, 2), cell: i});
+    }
+  }
+
+  const getType = id => types.find(t => t.id === id);
+  const getTypes = () => types.slice();
+
+  return {generate, getType, getTypes};
+})();

--- a/modules/ui/layers.js
+++ b/modules/ui/layers.js
@@ -209,6 +209,7 @@ function drawLayers() {
   if (layerIsOn("toggleBurgIcons")) drawBurgIcons();
   if (layerIsOn("toggleMilitary")) drawMilitary();
   if (layerIsOn("toggleMarkers")) drawMarkers();
+  if (layerIsOn("toggleResources")) drawResources();
   if (layerIsOn("toggleRulers")) rulers.draw();
   // scale bar
   // vignette
@@ -869,6 +870,18 @@ function toggleMarkers(event) {
   }
 }
 
+function toggleResources(event) {
+  if (!layerIsOn("toggleResources")) {
+    turnButtonOn("toggleResources");
+    drawResources();
+    if (event && isCtrlClick(event)) editStyle("resources");
+  } else {
+    if (event && isCtrlClick(event)) return editStyle("resources");
+    resources.selectAll("*").remove();
+    turnButtonOff("toggleResources");
+  }
+}
+
 function toggleLabels(event) {
   if (!layerIsOn("toggleLabels")) {
     turnButtonOn("toggleLabels");
@@ -1037,5 +1050,6 @@ function getLayer(id) {
   if (id === "toggleLabels") return $("#labels");
   if (id === "toggleBurgIcons") return $("#icons");
   if (id === "toggleMarkers") return $("#markers");
+  if (id === "toggleResources") return $("#resources");
   if (id === "toggleRulers") return $("#ruler");
 }

--- a/styles/ancient.json
+++ b/styles/ancient.json
@@ -99,6 +99,10 @@
     "rescale": 1,
     "filter": null
   },
+  "#resources": {
+    "opacity": null,
+    "filter": null
+  },
   "#prec": {
     "opacity": null,
     "stroke": "#000000",

--- a/styles/atlas.json
+++ b/styles/atlas.json
@@ -99,6 +99,10 @@
     "rescale": 1,
     "filter": null
   },
+  "#resources": {
+    "opacity": null,
+    "filter": null
+  },
   "#prec": {
     "opacity": null,
     "stroke": "#000000",

--- a/styles/clean.json
+++ b/styles/clean.json
@@ -100,6 +100,10 @@
     "rescale": null,
     "filter": null
   },
+  "#resources": {
+    "opacity": null,
+    "filter": null
+  },
   "#prec": {
     "opacity": null,
     "stroke": "#000000",

--- a/styles/cyberpunk.json
+++ b/styles/cyberpunk.json
@@ -99,6 +99,10 @@
     "rescale": 1,
     "filter": null
   },
+  "#resources": {
+    "opacity": null,
+    "filter": null
+  },
   "#prec": {
     "opacity": null,
     "stroke": "#000000",

--- a/styles/darkSeas.json
+++ b/styles/darkSeas.json
@@ -96,6 +96,10 @@
     "rescale": 1,
     "filter": null
   },
+  "#resources": {
+    "opacity": null,
+    "filter": null
+  },
   "#prec": {
     "opacity": null,
     "stroke": "#000000",

--- a/styles/default.json
+++ b/styles/default.json
@@ -99,6 +99,10 @@
     "rescale": 1,
     "filter": null
   },
+  "#resources": {
+    "opacity": null,
+    "filter": null
+  },
   "#prec": {
     "opacity": null,
     "stroke": "#000000",

--- a/styles/gloom.json
+++ b/styles/gloom.json
@@ -100,6 +100,10 @@
     "rescale": 1,
     "filter": null
   },
+  "#resources": {
+    "opacity": null,
+    "filter": null
+  },
   "#prec": {
     "opacity": null,
     "stroke": "#000000",

--- a/styles/light.json
+++ b/styles/light.json
@@ -99,6 +99,10 @@
     "rescale": 1,
     "filter": null
   },
+  "#resources": {
+    "opacity": null,
+    "filter": null
+  },
   "#prec": {
     "opacity": null,
     "stroke": "#000000",

--- a/styles/monochrome.json
+++ b/styles/monochrome.json
@@ -100,6 +100,10 @@
     "rescale": 1,
     "filter": null
   },
+  "#resources": {
+    "opacity": null,
+    "filter": null
+  },
   "#prec": {
     "opacity": null,
     "stroke": "#000000",

--- a/styles/night.json
+++ b/styles/night.json
@@ -99,6 +99,10 @@
     "rescale": null,
     "filter": "url(#dropShadow01)"
   },
+  "#resources": {
+    "opacity": null,
+    "filter": null
+  },
   "#prec": {
     "opacity": null,
     "stroke": "#ffffff",

--- a/styles/pale.json
+++ b/styles/pale.json
@@ -99,6 +99,10 @@
     "rescale": 1,
     "filter": null
   },
+  "#resources": {
+    "opacity": null,
+    "filter": null
+  },
   "#prec": {
     "opacity": null,
     "stroke": "#000000",

--- a/styles/watercolor.json
+++ b/styles/watercolor.json
@@ -99,6 +99,10 @@
     "rescale": 1,
     "filter": null
   },
+  "#resources": {
+    "opacity": null,
+    "filter": null
+  },
   "#prec": {
     "opacity": null,
     "stroke": "#000000",


### PR DESCRIPTION
## Summary
- implement resource assignment in `modules/resources-generator.js`
- render resources via new `draw-resources.js`
- create `config/resources.json` to configure resource types
- add `resources` layer elements and controls
- save/load resource data with maps
- include resources in styles

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687ca51ad60c832493b6332421d7ea28