### PR TITLE
Fix resources generation conflict and add tooltips

### DIFF
--- a/modules/renderers/draw-resources.js
+++ b/modules/renderers/draw-resources.js
@@ -7,7 +7,8 @@ function drawResources() {
     const type = Resources.getType(r.type);
     const color = type?.color || "#000";
     const size = 3;
-    return `<circle id="resource${r.i}" cx="${r.x}" cy="${r.y}" r="${size}" fill="${color}" />`;
+    const name = type?.name || "Unknown";
+    return `<circle id="resource${r.i}" cx="${r.x}" cy="${r.y}" r="${size}" fill="${color}" data-tip="${name}" />`;
   });
   resources.html(html.join(""));
   TIME && console.timeEnd("drawResources");

--- a/modules/resources-generator.js
+++ b/modules/resources-generator.js
@@ -58,10 +58,5 @@ window.Resources = (function () {
   const getTypes = () => types.slice();
 
   return {generate, regenerate, getType, getTypes};
-=======
-  const getType = id => types.find(t => t.id === id);
-  const getTypes = () => types.slice();
-
-  return {generate, getType, getTypes};
 
 })();


### PR DESCRIPTION
## Summary
- resolve merge conflict in `resources-generator.js`
- show resource type names on hover via `data-tip`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687d5e4bca4883249b6e11882c1fa042