### PR TITLE
Add editable resource deposits with size

### DIFF
--- a/config/resources.json
+++ b/config/resources.json
@@ -1,9 +1,9 @@
 [
-  {"id":1,"name":"Iron","color":"#b7410e","base":0.05,"type":"metal"},
-  {"id":2,"name":"Copper","color":"#b87333","base":0.04,"type":"metal"},
-  {"id":3,"name":"Gold","color":"#ffd700","base":0.01,"type":"metal"},
-  {"id":4,"name":"Coal","color":"#444","base":0.07,"type":"fuel"},
-  {"id":5,"name":"Oil","color":"#222","base":0.03,"type":"fuel"},
-  {"id":6,"name":"Mithril","color":"#8a8aff","base":0.005,"type":"magic"},
-  {"id":7,"name":"Mana Crystal","color":"#00ffff","base":0.005,"type":"magic"}
+  {"id":1,"name":"Iron","color":"#b7410e","base":0.05,"size":1,"type":"metal"},
+  {"id":2,"name":"Copper","color":"#b87333","base":0.04,"size":1,"type":"metal"},
+  {"id":3,"name":"Gold","color":"#ffd700","base":0.01,"size":1,"type":"metal"},
+  {"id":4,"name":"Coal","color":"#444","base":0.07,"size":1,"type":"fuel"},
+  {"id":5,"name":"Oil","color":"#222","base":0.03,"size":1,"type":"fuel"},
+  {"id":6,"name":"Mithril","color":"#8a8aff","base":0.005,"size":1,"type":"magic"},
+  {"id":7,"name":"Mana Crystal","color":"#00ffff","base":0.005,"size":1,"type":"magic"}
 ]

--- a/index.html
+++ b/index.html
@@ -4951,8 +4951,11 @@
       </div>
 
       <div id="resourcesEditor" class="dialog stable" style="display: none">
-        <div id="resourcesHeader" class="header" style="grid-template-columns: 13em 6em">
+        <div id="resourcesHeader" class="header" style="grid-template-columns: 1.5em 8em 5em 5em 5em">
+          <div></div>
           <div>Name&nbsp;</div>
+          <div>Base&nbsp;</div>
+          <div>Size&nbsp;</div>
           <div>Cells&nbsp;</div>
         </div>
 
@@ -4977,6 +4980,8 @@
             <button id="resourcesManuallyCancel" data-tip="Cancel assignment" class="icon-cancel"></button>
           </div>
           <button id="resourcesRegenerate" data-tip="Regenerate resources" class="icon-arrows-cw"></button>
+          <button id="resourcesAdd" data-tip="Add a custom resource" class="icon-plus"></button>
+          <label style="margin-left:5px"><input id="resourcesDisplaySize" type="checkbox"/>Display by size</label>
         </div>
       </div>
 

--- a/modules/renderers/draw-resources.js
+++ b/modules/renderers/draw-resources.js
@@ -3,10 +3,11 @@
 function drawResources() {
   TIME && console.time("drawResources");
   resources.selectAll("*").remove();
+  const bySize = Resources.getDisplayMode();
   const html = pack.resources.map(r => {
     const type = Resources.getType(r.type);
     const color = type?.color || "#000";
-    const size = 3;
+    const size = bySize ? (r.size || 1) * 3 : 3;
     const name = type?.name || "Unknown";
     return `<circle id="resource${r.i}" cx="${r.x}" cy="${r.y}" r="${size}" fill="${color}" data-tip="${name}" />`;
   });


### PR DESCRIPTION
## Summary
- add deposit size to resource config
- generate resources using deposit size
- allow display by deposit size
- extend Resources Editor to add/remove and edit resource types, base weight and size

## Testing
- `node -e "require('./modules/resources-generator.js');"` *(fails: ReferenceError: window is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_687d953025c48324b81241cb68806a75