### PR TITLE
Add configurable resource frequency and icon toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -4983,6 +4983,8 @@
           <button id="resourcesRegenerate" data-tip="Regenerate resources" class="icon-arrows-cw"></button>
           <button id="resourcesAdd" data-tip="Add a custom resource" class="icon-plus"></button>
           <label style="margin-left:5px"><input id="resourcesDisplaySize" type="checkbox"/>Display by size</label>
+          <label style="margin-left:5px"><input id="resourcesUseIcons" type="checkbox" checked/>Use icons</label>
+          <label style="margin-left:5px">Frequency: <input id="resourcesFrequency" type="number" min="0" max="1" step="0.01" value="0.1" style="width:4em"></label>
         </div>
       </div>
 

--- a/modules/renderers/draw-resources.js
+++ b/modules/renderers/draw-resources.js
@@ -5,13 +5,14 @@ function drawResources() {
   resources.selectAll("*").remove();
 
   const bySize = Resources.getDisplayMode();
+  const useIcons = Resources.getUseIcons();
 
   const html = pack.resources.map(r => {
     const type = Resources.getType(r.type);
     const color = type?.color || "#000";
     const name = type?.name || "Unknown";
 
-    if (bySize || !type?.icon) {
+    if (bySize || !useIcons || !type?.icon) {
       const size = bySize ? (r.size || 1) * 3 : 3;
       return `<circle id="resource${r.i}" cx="${r.x}" cy="${r.y}" r="${size}" fill="${color}" data-tip="${name}" />`;
     }

--- a/modules/resources-generator.js
+++ b/modules/resources-generator.js
@@ -3,6 +3,8 @@
 window.Resources = (function () {
   let types = [];
   let displayBySize = false;
+  let useIcons = true;
+  let frequency = 0.1; // overall spawn rate multiplier
 
   // region size used to group deposits for size similarity
   const REGION = 120;
@@ -51,7 +53,7 @@ window.Resources = (function () {
         return w;
       });
       const total = weights.reduce((a, b) => a + b, 0);
-      if (Math.random() >= total) continue;
+      if (Math.random() >= total * frequency) continue;
       let r = Math.random() * total;
       let resIndex = -1;
       for (let j = 0; j < weights.length; j++) {
@@ -84,7 +86,24 @@ window.Resources = (function () {
   const updateTypes = t => (types = t.slice());
   const setDisplayMode = value => (displayBySize = value);
   const getDisplayMode = () => displayBySize;
+  const setUseIcons = value => (useIcons = value);
+  const getUseIcons = () => useIcons;
+  const setFrequency = value => (frequency = +value);
+  const getFrequency = () => frequency;
 
-  return {generate, regenerate, getType, getTypes, updateTypes, setDisplayMode, getDisplayMode, getRandomSize};
+  return {
+    generate,
+    regenerate,
+    getType,
+    getTypes,
+    updateTypes,
+    setDisplayMode,
+    getDisplayMode,
+    setUseIcons,
+    getUseIcons,
+    setFrequency,
+    getFrequency,
+    getRandomSize
+  };
 
 })();

--- a/modules/ui/resources-editor.js
+++ b/modules/ui/resources-editor.js
@@ -7,6 +7,8 @@ function editResources() {
   const body = byId("resourcesBody");
   refreshResourcesEditor();
   byId("resourcesDisplaySize").checked = Resources.getDisplayMode();
+  byId("resourcesUseIcons").checked = Resources.getUseIcons();
+  byId("resourcesFrequency").value = Resources.getFrequency();
 
   if (modules.editResources) return;
   modules.editResources = true;
@@ -243,6 +245,19 @@ function editResources() {
   byId("resourcesDisplaySize").addEventListener("change", () => {
     Resources.setDisplayMode(byId("resourcesDisplaySize").checked);
     drawResources();
+  });
+  byId("resourcesUseIcons").addEventListener("change", () => {
+    Resources.setUseIcons(byId("resourcesUseIcons").checked);
+    drawResources();
+  });
+  byId("resourcesFrequency").addEventListener("change", () => {
+    const val = +byId("resourcesFrequency").value;
+    if (isNaN(val) || val < 0) {
+      byId("resourcesFrequency").value = Resources.getFrequency();
+      return tip("Please provide a valid frequency", false, "error");
+    }
+    Resources.setFrequency(val);
+    regenerateResources();
   });
 
   function addCustomResource() {


### PR DESCRIPTION
## Summary
- add global frequency multiplier for resources generation
- allow switching between icon and circle display
- expose new options in the Resources editor

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_687da86489448324b09361511d6ecdc1