### PR TITLE
Add per-resource visibility toggles

### DIFF
--- a/index.html
+++ b/index.html
@@ -4985,6 +4985,7 @@
           <label style="margin-left:5px"><input id="resourcesDisplaySize" type="checkbox"/>Display by size</label>
           <label style="margin-left:5px"><input id="resourcesUseIcons" type="checkbox" checked/>Use icons</label>
           <label style="margin-left:5px">Frequency: <input id="resourcesFrequency" type="number" min="0" max="1" step="0.01" value="0.1" style="width:4em"></label>
+          <div id="resourcesFilters" data-tip="Toggle resources visibility" style="display:inline-block; margin-left:5px"></div>
         </div>
       </div>
 

--- a/modules/renderers/draw-resources.js
+++ b/modules/renderers/draw-resources.js
@@ -7,7 +7,7 @@ function drawResources() {
   const bySize = Resources.getDisplayMode();
   const useIcons = Resources.getUseIcons();
 
-  const html = pack.resources.map(r => {
+  const html = pack.resources.filter(r => Resources.isTypeVisible(r.type)).map(r => {
     const type = Resources.getType(r.type);
     const color = type?.color || "#000";
     const name = type?.name || "Unknown";

--- a/modules/resources-generator.js
+++ b/modules/resources-generator.js
@@ -5,6 +5,7 @@ window.Resources = (function () {
   let displayBySize = false;
   let useIcons = true;
   let frequency = 0.1; // overall spawn rate multiplier
+  const hidden = new Set();
 
   // region size used to group deposits for size similarity
   const REGION = 120;
@@ -90,6 +91,11 @@ window.Resources = (function () {
   const getUseIcons = () => useIcons;
   const setFrequency = value => (frequency = +value);
   const getFrequency = () => frequency;
+  const hideType = id => hidden.add(+id);
+  const showType = id => hidden.delete(+id);
+  const toggleType = id => (hidden.has(+id) ? hidden.delete(+id) : hidden.add(+id));
+  const isTypeVisible = id => !hidden.has(+id);
+  const getHidden = () => Array.from(hidden);
 
   return {
     generate,
@@ -103,6 +109,11 @@ window.Resources = (function () {
     getUseIcons,
     setFrequency,
     getFrequency,
+    hideType,
+    showType,
+    toggleType,
+    isTypeVisible,
+    getHidden,
     getRandomSize
   };
 

--- a/modules/ui/resources-editor.js
+++ b/modules/ui/resources-editor.js
@@ -5,6 +5,7 @@ function editResources() {
   if (!layerIsOn("toggleResources")) toggleResources();
 
   const body = byId("resourcesBody");
+  const filters = byId("resourcesFilters");
   refreshResourcesEditor();
   byId("resourcesDisplaySize").checked = Resources.getDisplayMode();
   byId("resourcesUseIcons").checked = Resources.getUseIcons();
@@ -78,6 +79,23 @@ function editResources() {
     body.innerHTML = lines;
     body.querySelector("div.states")?.classList.add("selected");
     byId("resourcesFooterNumber").textContent = pack.resources.length;
+    updateFilters();
+  }
+
+  function updateFilters() {
+    const types = Resources.getTypes();
+    const checkboxes = types
+      .map(t => `<label style="margin-left:3px"><input type="checkbox" data-id="${t.id}">${t.name}</label>`)
+      .join("");
+    filters.innerHTML = checkboxes;
+    filters.querySelectorAll("input").forEach(input => {
+      input.checked = Resources.isTypeVisible(+input.dataset.id);
+      input.addEventListener("change", () => {
+        if (input.checked) Resources.showType(input.dataset.id);
+        else Resources.hideType(input.dataset.id);
+        drawResources();
+      });
+    });
   }
 
   function closeResourcesEditor() {
@@ -196,6 +214,7 @@ function editResources() {
     if (type) type.name = el.value;
     Resources.updateTypes(types);
     drawResources();
+    updateFilters();
   }
 
   function resourceChangeBase(el) {
@@ -209,6 +228,7 @@ function editResources() {
     const type = types.find(t => t.id === resource);
     if (type) type.base = val;
     Resources.updateTypes(types);
+    updateFilters();
   }
 
   function resourceChangeSize(el) {
@@ -222,6 +242,7 @@ function editResources() {
     const type = types.find(t => t.id === resource);
     if (type) type.size = val;
     Resources.updateTypes(types);
+    updateFilters();
   }
 
   function resourceChangeIcon(el) {
@@ -231,6 +252,7 @@ function editResources() {
     if (type) type.icon = el.value;
     Resources.updateTypes(types);
     drawResources();
+    updateFilters();
   }
 
   function removeCustomResource(el) {
@@ -239,6 +261,7 @@ function editResources() {
     Resources.updateTypes(types);
     refreshResourcesEditor();
     drawResources();
+    updateFilters();
   }
 
   byId("resourcesAdd").addEventListener("click", addCustomResource);


### PR DESCRIPTION
## Summary
- allow individual resource types to be hidden
- filter resources in the renderer
- expose visibility API in `Resources`
- display checkboxes in the Resources editor to toggle types

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687dac15801c8324bd00eb7364da257d