### PR TITLE
Enhance resource visibility UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -4951,8 +4951,9 @@
       </div>
 
       <div id="resourcesEditor" class="dialog stable" style="display: none">
-        <div id="resourcesHeader" class="header" style="grid-template-columns: 1.5em 2em 8em 5em 5em 5em">
+        <div id="resourcesHeader" class="header" style="grid-template-columns: 1.5em 1.5em 2em 8em 5em 5em 5em">
           <div></div>
+          <div>Show&nbsp;</div>
           <div>Icon&nbsp;</div>
           <div>Name&nbsp;</div>
           <div>Base&nbsp;</div>
@@ -4985,7 +4986,7 @@
           <label style="margin-left:5px"><input id="resourcesDisplaySize" type="checkbox"/>Display by size</label>
           <label style="margin-left:5px"><input id="resourcesUseIcons" type="checkbox" checked/>Use icons</label>
           <label style="margin-left:5px">Frequency: <input id="resourcesFrequency" type="number" min="0" max="1" step="0.01" value="0.1" style="width:4em"></label>
-          <div id="resourcesFilters" data-tip="Toggle resources visibility" style="display:inline-block; margin-left:5px"></div>
+          <div id="resourcesFilters" data-tip="Toggle resources visibility" style="display:none; margin-left:5px"></div>
         </div>
       </div>
 

--- a/modules/resources-generator.js
+++ b/modules/resources-generator.js
@@ -2,6 +2,7 @@
 
 window.Resources = (function () {
   let types = [];
+  const STORAGE_KEY = "resourcesConfig";
   let displayBySize = false;
   let useIcons = true;
   let frequency = 0.1; // overall spawn rate multiplier
@@ -26,8 +27,14 @@ window.Resources = (function () {
 
   async function loadConfig() {
     if (types.length) return types;
+    const stored = JSON.safeParse(localStorage.getItem(STORAGE_KEY));
+    if (stored?.length) {
+      types = stored;
+      return types;
+    }
     try {
       types = await (await fetch("config/resources.json")).json();
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(types));
     } catch (e) {
       console.error("Failed to load resources config", e);
       types = [];
@@ -84,7 +91,10 @@ window.Resources = (function () {
 
   const getType = id => types.find(t => t.id === id);
   const getTypes = () => types.slice();
-  const updateTypes = t => (types = t.slice());
+  const updateTypes = t => {
+    types = t.slice();
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(types));
+  };
   const setDisplayMode = value => (displayBySize = value);
   const getDisplayMode = () => displayBySize;
   const setUseIcons = value => (useIcons = value);

--- a/modules/ui/resources-editor.js
+++ b/modules/ui/resources-editor.js
@@ -45,6 +45,7 @@ function editResources() {
     else if (cl.contains("resourceBase")) resourceChangeBase(el);
     else if (cl.contains("resourceSize")) resourceChangeSize(el);
     else if (cl.contains("resourceIcon")) resourceChangeIcon(el);
+    else if (cl.contains("resourceVisible")) resourceToggleVisibility(el);
   });
 
   function refreshResourcesEditor() {
@@ -60,6 +61,7 @@ function editResources() {
         const count = counts[t.id] || 0;
         return `<div class="states resources" data-id="${t.id}" data-name="${t.name}" data-color="${t.color}" data-base="${t.base}" data-size="${t.size}" data-icon="${t.icon || ''}" data-cells="${count}">`+
           `<fill-box fill="${t.color}" class="resourceColor"></fill-box>`+
+          `<input class="resourceVisible" type="checkbox" ${Resources.isTypeVisible(t.id) ? "checked" : ""}/>`+
           `<input class="resourceIcon" value="${t.icon || ''}" style="width:2em"/>`+
           `<input class="resourceName" value="${t.name}" style="width:8em"/>`+
           `<input class="resourceBase" type="number" step="0.001" value="${t.base}" style="width:4em"/>`+
@@ -71,6 +73,7 @@ function editResources() {
       .join("");
     lines += `<div class="states resources" data-id="0" data-name="None" data-color="#eee" data-base="0" data-size="1" data-icon="" data-cells="0">`+
              `<fill-box fill="#eee" class="resourceColor"></fill-box>`+
+             `<input class="resourceVisible" type="checkbox" checked disabled/>`+
              `<input class="resourceIcon" value="" style="width:2em"/>`+
              `<div class="resourceName" style="width:8em">None</div>`+
              `<input class="resourceBase" type="number" step="0.001" value="0" style="width:4em"/>`+
@@ -83,18 +86,10 @@ function editResources() {
   }
 
   function updateFilters() {
-    const types = Resources.getTypes();
-    const checkboxes = types
-      .map(t => `<label style="margin-left:3px"><input type="checkbox" data-id="${t.id}">${t.name}</label>`)
-      .join("");
-    filters.innerHTML = checkboxes;
-    filters.querySelectorAll("input").forEach(input => {
-      input.checked = Resources.isTypeVisible(+input.dataset.id);
-      input.addEventListener("change", () => {
-        if (input.checked) Resources.showType(input.dataset.id);
-        else Resources.hideType(input.dataset.id);
-        drawResources();
-      });
+    body.querySelectorAll("div.states.resources").forEach(line => {
+      const id = +line.dataset.id;
+      const cb = line.querySelector(".resourceVisible");
+      if (cb) cb.checked = Resources.isTypeVisible(id);
     });
   }
 
@@ -253,6 +248,13 @@ function editResources() {
     Resources.updateTypes(types);
     drawResources();
     updateFilters();
+  }
+
+  function resourceToggleVisibility(el) {
+    const resource = +el.parentNode.dataset.id;
+    if (el.checked) Resources.showType(resource);
+    else Resources.hideType(resource);
+    drawResources();
   }
 
   function removeCustomResource(el) {


### PR DESCRIPTION
## Summary
- add per-resource visibility checkbox to the editor
- hide old filter section
- store custom resources in localStorage

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687db4d6858c8324baf35fc4731d1208