### PR TITLE
Fix resource editor show/icon header overlap

### DIFF
--- a/index.css
+++ b/index.css
@@ -1437,8 +1437,15 @@ div.totalLine > div {
   display: inline-block;
 }
 
-div.states > input {
+div.states > input:not([type="checkbox"]) {
   width: 7em;
+  background: none;
+  border: 0;
+}
+
+div.states > input[type="checkbox"] {
+  width: 1em;
+  margin-right: 0.2em;
   background: none;
   border: 0;
 }

--- a/index.html
+++ b/index.html
@@ -4951,7 +4951,7 @@
       </div>
 
       <div id="resourcesEditor" class="dialog stable" style="display: none">
-        <div id="resourcesHeader" class="header" style="grid-template-columns: 1.5em 1.5em 2em 8em 5em 5em 5em">
+        <div id="resourcesHeader" class="header" style="grid-template-columns: 1.5em 3.5em 3em 8em 5em 5em 5em">
           <div></div>
           <div>Show&nbsp;</div>
           <div>Icon&nbsp;</div>


### PR DESCRIPTION
## Summary
- adjust width rules for resource table inputs so checkboxes use narrow width
- widen the "Show" and "Icon" columns in resource editor header

## Testing
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_e_687dc2d1fb5c83249bd896072fcf4870