### PR TITLE
Expand underground resources

### DIFF
--- a/config/resources.json
+++ b/config/resources.json
@@ -5,5 +5,16 @@
   {"id":4,"name":"Coal","color":"#444","base":0.07,"size":4,"type":"fuel","icon":"🪨"},
   {"id":5,"name":"Oil","color":"#222","base":0.03,"size":3,"type":"fuel","icon":"🛢️"},
   {"id":6,"name":"Mithril","color":"#8a8aff","base":0.005,"size":1,"type":"magic","icon":"🔮"},
-  {"id":7,"name":"Mana Crystal","color":"#00ffff","base":0.005,"size":1,"type":"magic","icon":"🔷"}
+  {"id":7,"name":"Mana Crystal","color":"#00ffff","base":0.005,"size":1,"type":"magic","icon":"🔷"},
+  {"id":8,"name":"Salt","color":"#e0e0e0","base":0.04,"size":2,"type":"mineral","icon":"🧂"},
+  {"id":9,"name":"Clay","color":"#b96c4b","base":0.06,"size":3,"type":"building","icon":"🏺"},
+  {"id":10,"name":"Tin","color":"#c0c0c0","base":0.02,"size":1,"type":"metal","icon":"🥫"},
+  {"id":11,"name":"Limestone","color":"#f0f0c9","base":0.05,"size":3,"type":"building","icon":"🗿"},
+  {"id":12,"name":"Sandstone","color":"#d2a679","base":0.05,"size":3,"type":"building","icon":"🟫"},
+  {"id":13,"name":"Magical Timbers","color":"#4b5320","base":0.02,"size":2,"type":"organic","icon":"🪵"},
+  {"id":14,"name":"Sulfur","color":"#f2d21b","base":0.015,"size":1,"type":"mineral","icon":"🧪"},
+  {"id":15,"name":"Saltpeter","color":"#ddddbb","base":0.015,"size":1,"type":"mineral","icon":"💥"},
+  {"id":16,"name":"Lead","color":"#555555","base":0.03,"size":2,"type":"metal","icon":"🔗"},
+  {"id":17,"name":"Silver","color":"#b9b9b9","base":0.02,"size":1,"type":"metal","icon":"🪙"},
+  {"id":18,"name":"Gems","color":"#aa00ff","base":0.01,"size":1,"type":"gem","icon":"💎"}
 ]

--- a/modules/markers-generator.js
+++ b/modules/markers-generator.js
@@ -228,7 +228,7 @@ window.Markers = (function () {
   function addMine(id, cell) {
     const {cells} = pack;
 
-    const resources = {salt: 5, gold: 2, silver: 4, copper: 2, iron: 3, lead: 1, tin: 1};
+    const resources = {salt: 5, clay: 4, limestone: 3, sandstone: 2, coal: 4, tin: 1, copper: 2, iron: 3, lead: 1, silver: 2, gold: 1, gems: 1, sulfur: 1, saltpeter: 1, "Magical Timbers": 1};
     const resource = rw(resources);
     const burg = pack.burgs[cells.burg[cell]];
     const name = `${burg.name} — ${resource} mining town`;

--- a/modules/resources-generator.js
+++ b/modules/resources-generator.js
@@ -48,6 +48,11 @@ window.Resources = (function () {
         if (t.type === "metal" && height > 60) w *= 3;
         if (t.type === "fuel" && height < 60 && [3,4,5,7,8,9,12].includes(biome)) w *= 2;
         if (t.type === "magic" && height > 70) w *= 5;
+        if (t.type === "building" && height < 60) w *= 2;
+        if (t.type === "building" && cells.pop[i]) w *= 1 + cells.pop[i] / 20;
+        if (t.type === "organic" && [5,6,7,8,9].includes(biome)) w *= 2;
+        if (t.type === "mineral" && [1,2,12].includes(biome)) w *= 2;
+        if (t.type === "gem" && height > 70) w *= 3;
         return w;
       });
       const total = weights.reduce((a, b) => a + b, 0);


### PR DESCRIPTION
## Summary
- extend default resource list with common ores and materials
- adjust mine marker random resources
- add generation heuristics for new resource types

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6880165035b88324ac4b47742bf47f74