### PR TITLE
Add deposit size integration

### DIFF
--- a/index.html
+++ b/index.html
@@ -8133,6 +8133,7 @@
     <script src="utils/numberUtils.js?v=1.99.00"></script>
     <script src="utils/polyfills.js?v=1.99.00"></script>
     <script src="utils/probabilityUtils.js?v=1.99.05"></script>
+    <script src="utils/depositUtils.js?v=1.0.0"></script>
     <script src="utils/stringUtils.js?v=1.106.0"></script>
     <script src="utils/languageUtils.js?v=1.99.00"></script>
     <script src="utils/unitUtils.js?v=1.99.00"></script>

--- a/modules/renderers/draw-resources.js
+++ b/modules/renderers/draw-resources.js
@@ -13,8 +13,9 @@ function drawResources() {
     const name = type?.name || "Unknown";
 
     if (bySize || !useIcons || !type?.icon) {
-      const size = bySize ? (r.size || 1) * 3 : 3;
-      return `<circle id="resource${r.i}" cx="${r.x}" cy="${r.y}" r="${size}" fill="${color}" data-tip="${name}" />`;
+      const tons = r.tons || 1;
+      const radius = bySize ? getRenderRadius(tons, scale) : 3;
+      return `<circle id="resource${r.i}" cx="${r.x}" cy="${r.y}" r="${radius}" fill="${color}" data-tip="${name}" />`;
     }
 
     const icon = type.icon;

--- a/modules/resources-generator.js
+++ b/modules/resources-generator.js
@@ -25,6 +25,11 @@ window.Resources = (function () {
     return Math.max(1, Math.round(base * factor));
   }
 
+  function getDepositTons(type, x, y) {
+    const r = regionRandom(x, y, type.id + "_tons");
+    return getDepositSize(type.name, r);
+  }
+
   async function loadConfig() {
     if (types.length) return types;
     const stored = JSON.safeParse(localStorage.getItem(STORAGE_KEY));
@@ -151,13 +156,14 @@ window.Resources = (function () {
       const type = types[resIndex];
       const [x, y] = cells.p[i];
       const size = getRandomSize(type, x, y);
+      const tons = getDepositTons(type, x, y);
       const affected = size > 1 ? findAll(x, y, size) : [i];
       affected.forEach(c => {
         if (cells.h[c] < 20 || used.has(c)) return;
         cells.resource[c] = type.id;
         used.add(c);
       });
-      pack.resources.push({i: ++id, type: type.id, x: rn(x, 2), y: rn(y, 2), cell: i, size});
+      pack.resources.push({i: ++id, type: type.id, x: rn(x, 2), y: rn(y, 2), cell: i, size, tons});
     }
   }
   async function regenerate() {
@@ -201,6 +207,7 @@ window.Resources = (function () {
     isTypeVisible,
     getHidden,
     getRandomSize,
+    getDepositTons,
     getResourceWeight
   };
 

--- a/modules/ui/resources-editor.js
+++ b/modules/ui/resources-editor.js
@@ -166,7 +166,8 @@ function editResources() {
         const id = last(pack.resources)?.i + 1 || 1;
         const type = Resources.getType(typeId);
         const size = Resources.getRandomSize(type, x, y);
-        pack.resources.push({i: id, type: typeId, x: rn(x,2), y: rn(y,2), cell: i, size});
+        const tons = Resources.getDepositTons(type, x, y);
+        pack.resources.push({i: id, type: typeId, x: rn(x,2), y: rn(y,2), cell: i, size, tons});
       }
     });
     drawResources();

--- a/tests/depositUtils.test.js
+++ b/tests/depositUtils.test.js
@@ -1,0 +1,15 @@
+const {DepositSizeTiers, getDepositSize, getRenderRadius} = require('../utils/depositUtils.js');
+
+test('getDepositSize uses tier range and random value', () => {
+  const oldRandom = Math.random;
+  Math.random = () => 0; // always pick lowest tier
+  const tons = getDepositSize('Iron', 0);
+  Math.random = oldRandom;
+  expect(tons).toBe(DepositSizeTiers[7].min); // Iron min tier is 8
+});
+
+test('getRenderRadius scales logarithmically and clamps', () => {
+  expect(getRenderRadius(10000, 1)).toBe(4); // log10(10000)=4
+  expect(getRenderRadius(1e10, 10)).toBe(50); // clamped to max
+  expect(getRenderRadius(1, 0)).toBe(2); // clamped to min
+});

--- a/utils/depositUtils.js
+++ b/utils/depositUtils.js
@@ -1,0 +1,67 @@
+"use strict";
+
+// internal helpers
+function minmax(value, min, max) {
+  return Math.min(Math.max(value, min), max);
+}
+
+function lerp(a, b, t) {
+  return a + (b - a) * t;
+}
+
+// Global deposit size tiers (metric tons)
+const DepositSizeTiers = [
+  { tier: 1, min: 1,     max: 5 },         // trace deposits
+  { tier: 2, min: 5,     max: 20 },        // very small
+  { tier: 3, min: 20,    max: 50 },        // small
+  { tier: 4, min: 50,    max: 200 },       // medium-small
+  { tier: 5, min: 200,   max: 1000 },      // medium
+  { tier: 6, min: 1000,  max: 5000 },      // large
+  { tier: 7, min: 5000,  max: 20000 },     // very large
+  { tier: 8, min: 20000, max: 100000 },    // mega
+  { tier: 9, min: 100000,max: 500000 },    // regional
+  { tier:10, min: 500000,max: 2000000 },   // continental
+  { tier:11, min: 2000000,max: 10000000 }, // extreme
+  { tier:12, min: 10000000,max: 50000000 } // mythical
+];
+
+// Resource → size tier mapping
+const ResourceSizeTiers = {
+  "Iron": [8, 11],
+  "Copper": [6, 9],
+  "Gold": [2, 4],
+  "Silver": [3, 5],
+  "Tin": [3, 6],
+  "Lead": [4, 7],
+  "Coal": [9, 12],
+  "Oil": [8, 11],
+  "Salt": [7, 10],
+  "Clay": [6, 9],
+  "Limestone": [7, 10],
+  "Sandstone": [7, 10],
+  "Sulfur": [3, 6],
+  "Saltpeter": [2, 4],
+  "Magical Timbers": [3, 6],
+  "Gems": [2, 5],
+  "Mithril": [1, 3],
+  "Mana Crystal": [1, 3]
+};
+
+function getDepositSize(resourceName, randomValue) {
+  const range = ResourceSizeTiers[resourceName] || [1, 1];
+  const [minTier, maxTier] = range;
+  const tierIndex = minTier + Math.floor(Math.random() * (maxTier - minTier + 1));
+  const tier = DepositSizeTiers[tierIndex - 1];
+  const tons = lerp(tier.min, tier.max, minmax(randomValue, 0, 1));
+  return Math.round(tons);
+}
+
+function getRenderRadius(depositTons, mapScale) {
+  const base = Math.log10(Math.max(depositTons, 1));
+  const radius = base * mapScale;
+  return minmax(radius, 2, 50);
+}
+
+if (typeof module !== "undefined") {
+  module.exports = {DepositSizeTiers, ResourceSizeTiers, getDepositSize, getRenderRadius};
+}


### PR DESCRIPTION
## Summary
- integrate `depositUtils` with resource generation
- store deposit tonnage on resource spots
- scale resource icons using `getRenderRadius`
- expose deposit utilities to UI

## Testing
- `npm test` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68813bacfe1c8324ba2a7f3d5d983094