### PR TITLE
Add tooltip and editing for resources layer

### DIFF
--- a/modules/ui/editors.js
+++ b/modules/ui/editors.js
@@ -31,6 +31,7 @@ function clicked() {
   else if (grand.id === "markers" || great.id === "markers") editMarker();
   else if (grand.id === "coastline") editCoastline();
   else if (grand.id === "lakes") editLake();
+  else if (grand.id === "resources") editResourceSpot(el.id);
   else if (great.id === "armies") editRegiment();
 }
 

--- a/modules/ui/general.js
+++ b/modules/ui/general.js
@@ -121,6 +121,20 @@ function showMapTooltip(point, e, i, g) {
   const land = pack.cells.h[i] >= 20;
 
   // specific elements
+  if (group === "resources") {
+    const resId = +e.target.id.slice(8);
+    const res = pack.resources.find(r => r.i === resId);
+    if (res) {
+      const type = Resources.getType(res.type);
+      const name = type?.name || "Unknown";
+      const tipText = `${name}: ${res.tons.toLocaleString()} tons`;
+      tip(tipText + ". Click to edit");
+      const editor = byId("resourcesEditor");
+      if (editor?.offsetParent) highlightEditorLine(editor, res.type, 5000);
+    }
+    return;
+  }
+
   if (group === "armies") return tip(e.target.parentNode.dataset.name + ". Click to edit");
 
   if (group === "emblems" && e.target.tagName === "use") {

--- a/modules/ui/resources-editor.js
+++ b/modules/ui/resources-editor.js
@@ -298,3 +298,20 @@ function editResources() {
     refreshResourcesEditor();
   }
 }
+
+function editResourceSpot(id) {
+  if (customization) return;
+  const resId = +id.replace("resource", "");
+  const resource = pack.resources.find(r => r.i === resId);
+  if (!resource) return;
+  editResources();
+  setTimeout(() => {
+    const body = byId("resourcesBody");
+    const line = body.querySelector(`div[data-id='${resource.type}']`);
+    if (line) {
+      body.querySelectorAll("div.selected").forEach(el => el.classList.remove("selected"));
+      line.classList.add("selected");
+      line.scrollIntoView({block: "center"});
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- show resource info on hover
- allow clicking resource spots to open Resources Editor with its type selected

## Testing
- `npm run lint`
- `npm test` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68814a8c7d5c8324a4ee921b1ca1ed6e