### PR TITLE
Fix resource layer zoom scaling and hover

### DIFF
--- a/modules/renderers/draw-resources.js
+++ b/modules/renderers/draw-resources.js
@@ -17,7 +17,8 @@ function drawResources() {
       const tons = r.tons || 1;
       const tipText = `${name}: ${tons.toLocaleString()} tons`;
 
-      const radius = bySize ? getRenderRadius(tons, scale) : 3;
+      // radius should not depend on current zoom when redrawn
+      const radius = bySize ? getRenderRadius(tons, 1) : 3;
       const labelSize = Math.max(radius * 1.5, 8);
 
       if (bySize || !useIcons || !type?.icon) {

--- a/modules/ui/general.js
+++ b/modules/ui/general.js
@@ -122,7 +122,10 @@ function showMapTooltip(point, e, i, g) {
 
   // specific elements
   if (group === "resources") {
-    const resId = +e.target.id.slice(8);
+    // event target may be a child element without an id
+    let el = e.target;
+    while (el && (!el.id || !el.id.startsWith("resource"))) el = el.parentNode;
+    const resId = el ? +el.id.replace("resource", "") : NaN;
     const res = pack.resources.find(r => r.i === resId);
     if (res) {
       const type = Resources.getType(res.type);


### PR DESCRIPTION
## Summary
- keep resource deposit radius consistent regardless of zoom
- ensure resource hover tooltip works when hovering icons

## Testing
- `npx eslint modules/renderers/draw-resources.js modules/ui/general.js`
- `npm test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jest)*

------
https://chatgpt.com/codex/tasks/task_e_68816779852483248945fcdf455c33e0