### PR TITLE
Add hidden resource discovery system

### DIFF
--- a/index.html
+++ b/index.html
@@ -4986,6 +4986,7 @@
           <label style="margin-left:5px"><input id="resourcesDisplaySize" type="checkbox"/>Display by size</label>
           <label style="margin-left:5px"><input id="resourcesUseIcons" type="checkbox" checked/>Use icons</label>
           <label style="margin-left:5px">Frequency: <input id="resourcesFrequency" type="number" min="0" max="1" step="0.01" value="0.1" style="width:4em"></label>
+          <label style="margin-left:5px"><input id="showHiddenResources" type="checkbox"/>Show undiscovered resources</label>
           <div id="resourcesFilters" data-tip="Toggle resources visibility" style="display:none; margin-left:5px"></div>
         </div>
       </div>

--- a/main.js
+++ b/main.js
@@ -84,6 +84,7 @@ let anchors = icons.append("g").attr("id", "anchors");
 let armies = viewbox.append("g").attr("id", "armies");
 let markers = viewbox.append("g").attr("id", "markers");
 let resources = viewbox.append("g").attr("id", "resources");
+let hiddenResources = viewbox.append("g").attr("id", "hiddenResources").style("display","none");
 let fogging = viewbox
   .append("g")
   .attr("id", "fogging-cont")
@@ -648,7 +649,7 @@ async function generate(options) {
     Rivers.generate();
     Biomes.define();
 
-    await Resources.generate(); // generate resources before ranking cells so cultures can form around them
+    await Resources.generateHiddenResources();
 
     rankCells();
     Cultures.generate();

--- a/modules/burgs-and-states.js
+++ b/modules/burgs-and-states.js
@@ -377,6 +377,11 @@ window.BurgsAndStates = (() => {
     }
 
     TIME && console.timeEnd("expandStates");
+    if (pack.cells.hiddenResource) {
+      states.forEach(s => {
+        if (s.i && !s.removed) Resources.revealResourcesForCiv(s.i);
+      });
+    }
   };
 
   const normalizeStates = () => {

--- a/modules/renderers/draw-resources.js
+++ b/modules/renderers/draw-resources.js
@@ -1,8 +1,9 @@
 "use strict";
 
-function drawResources() {
+function drawResources(showHidden = Resources.getShowHidden()) {
   TIME && console.time("drawResources");
   resources.selectAll("*").remove();
+  hiddenResources?.selectAll("*").remove();
 
   const bySize = Resources.getDisplayMode();
   const useIcons = Resources.getUseIcons();
@@ -52,5 +53,22 @@ function drawResources() {
     });
 
   resources.html(html.join(""));
+
+  if (showHidden && pack.hiddenResources) {
+    const hiddenHtml = pack.hiddenResources
+      .filter(r => Resources.isTypeVisible(r.type))
+      .map(r => {
+        const type = Resources.getType(r.type);
+        const color = type?.color || "#000";
+        const tons = r.tons || 1;
+        const radius = bySize ? getRenderRadius(tons, 1) * 0.6 : 2;
+        const opacity = 0.5;
+        return `<circle cx="${r.x}" cy="${r.y}" r="${radius}" fill="${color}" opacity="${opacity}" />`;
+      });
+    hiddenResources.html(hiddenHtml.join(""));
+    hiddenResources.style("display", null);
+  } else {
+    hiddenResources?.style("display", "none");
+  }
   TIME && console.timeEnd("drawResources");
 }

--- a/modules/resources-generator.js
+++ b/modules/resources-generator.js
@@ -6,6 +6,7 @@ window.Resources = (function () {
   let displayBySize = false;
   let useIcons = true;
   let frequency = 0.1; // overall spawn rate multiplier
+  let showHiddenResources = false;
   const hidden = new Set();
 
   // region size used to group deposits for size similarity
@@ -20,14 +21,94 @@ window.Resources = (function () {
 
   function getRandomSize(type, x, y) {
     const base = type.size || 1;
-    const r = regionRandom(x, y, type.id);
-    const factor = 0.8 + r * 0.4 + Math.random() * 0.2;
+    const r1 = regionRandom(x, y, type.id);
+    const r2 = regionRandom(x, y, type.id + "_size");
+    const factor = 0.8 + r1 * 0.4 + r2 * 0.2;
     return Math.max(1, Math.round(base * factor));
   }
 
   function getDepositTons(type, x, y) {
     const r = regionRandom(x, y, type.id + "_tons");
     return getDepositSize(type.name, r);
+  }
+
+  async function generateHiddenResources() {
+    await loadConfig();
+    const {cells} = pack;
+    const tectonicMap = computeTectonicZones();
+    cells.hiddenResource = new Uint8Array(cells.i.length);
+    cells.visibleResource = new Uint8Array(cells.i.length);
+    cells.hiddenDeposit = new Uint16Array(cells.i.length);
+    cells.visibleDeposit = new Uint16Array(cells.i.length);
+    pack.hiddenResources = [];
+    pack.resources = [];
+    const used = new Set();
+    let id = 0;
+    for (const i of cells.i) {
+      if (cells.h[i] < 20 || used.has(i)) continue;
+      const height = cells.h[i];
+      const biome = cells.biome[i];
+      const pop = cells.pop ? cells.pop[i] : 0;
+      const tectonic = tectonicMap[i];
+      const weights = types.map(t => getResourceWeight(t, height, biome, pop, tectonic));
+      const total = weights.reduce((a, b) => a + b, 0);
+      const presence = regionRandom(cells.p[i][0], cells.p[i][1], "res_presence");
+      if (presence >= total) continue;
+      let r = regionRandom(cells.p[i][0], cells.p[i][1], "res_type") * total;
+      let resIndex = -1;
+      for (let j = 0; j < weights.length; j++) {
+        r -= weights[j];
+        if (r <= 0) {
+          resIndex = j;
+          break;
+        }
+      }
+      if (resIndex === -1) continue;
+      const type = types[resIndex];
+      const [x, y] = cells.p[i];
+      const size = getRandomSize(type, x, y);
+      const tons = getDepositTons(type, x, y);
+      const affected = size > 1 ? findAll(x, y, size) : [i];
+      const depositId = ++id;
+      affected.forEach(c => {
+        if (cells.h[c] < 20 || used.has(c)) return;
+        cells.hiddenResource[c] = type.id;
+        cells.hiddenDeposit[c] = depositId;
+        used.add(c);
+      });
+      pack.hiddenResources.push({i: depositId, type: type.id, x: rn(x, 2), y: rn(y, 2), cell: i, size, tons});
+    }
+  }
+
+  function revealResourcesForCiv(civId) {
+    const {cells, hiddenResources, resources, states} = pack;
+    if (!cells.hiddenResource) return;
+    for (const i of cells.i) {
+      if (cells.state[i] !== civId) continue;
+      const [x, y] = cells.p[i];
+      const neighbors = findAll(x, y, 2);
+      neighbors.forEach(n => {
+        const typeId = cells.hiddenResource[n];
+        if (!typeId || cells.visibleResource[n]) return;
+        let chance = 0.1 * (states[civId]?.expansionism || 1);
+        if (cells.h[n] > 50) chance += 0.2;
+        if (Math.random() > chance) return;
+        const depId = cells.hiddenDeposit[n];
+        const index = hiddenResources.findIndex(r => r.i === depId);
+        if (index === -1) return;
+        const dep = hiddenResources.splice(index, 1)[0];
+        const affected = dep.size > 1 ? findAll(dep.x, dep.y, dep.size) : [dep.cell];
+        affected.forEach(c => {
+          if (cells.hiddenDeposit[c] !== depId) return;
+          cells.hiddenResource[c] = 0;
+          cells.hiddenDeposit[c] = 0;
+          cells.visibleResource[c] = typeId;
+          cells.visibleDeposit[c] = dep.i;
+        });
+        resources.push(dep);
+      });
+    }
+    if (window.drawResources) drawResources(showHiddenResources);
   }
 
   async function loadConfig() {
@@ -168,7 +249,7 @@ window.Resources = (function () {
   }
   async function regenerate() {
     await generate();
-    if (window.drawResources) drawResources();
+    if (window.drawResources) drawResources(showHiddenResources);
   }
 
   const getType = id => types.find(t => t.id === id);
@@ -183,6 +264,8 @@ window.Resources = (function () {
   const getUseIcons = () => useIcons;
   const setFrequency = value => (frequency = +value);
   const getFrequency = () => frequency;
+  const setShowHidden = value => (showHiddenResources = value);
+  const getShowHidden = () => showHiddenResources;
   const hideType = id => hidden.add(+id);
   const showType = id => hidden.delete(+id);
   const toggleType = id => (hidden.has(+id) ? hidden.delete(+id) : hidden.add(+id));
@@ -192,6 +275,8 @@ window.Resources = (function () {
   return {
     generate,
     regenerate,
+    generateHiddenResources,
+    revealResourcesForCiv,
     getType,
     getTypes,
     updateTypes,
@@ -201,6 +286,8 @@ window.Resources = (function () {
     getUseIcons,
     setFrequency,
     getFrequency,
+    setShowHidden,
+    getShowHidden,
     hideType,
     showType,
     toggleType,

--- a/modules/ui/layers.js
+++ b/modules/ui/layers.js
@@ -873,7 +873,7 @@ function toggleMarkers(event) {
 function toggleResources(event) {
   if (!layerIsOn("toggleResources")) {
     turnButtonOn("toggleResources");
-    drawResources();
+    drawResources(Resources.getShowHidden());
     if (event && isCtrlClick(event)) editStyle("resources");
   } else {
     if (event && isCtrlClick(event)) return editStyle("resources");

--- a/modules/ui/resources-editor.js
+++ b/modules/ui/resources-editor.js
@@ -10,6 +10,7 @@ function editResources() {
   byId("resourcesDisplaySize").checked = Resources.getDisplayMode();
   byId("resourcesUseIcons").checked = Resources.getUseIcons();
   byId("resourcesFrequency").value = Resources.getFrequency();
+  byId("showHiddenResources").checked = Resources.getShowHidden();
 
   if (modules.editResources) return;
   modules.editResources = true;
@@ -170,7 +171,7 @@ function editResources() {
         pack.resources.push({i: id, type: typeId, x: rn(x,2), y: rn(y,2), cell: i, size, tons});
       }
     });
-    drawResources();
+    drawResources(Resources.getShowHidden());
   }
 
   function applyResourcesManualAssign() {
@@ -200,7 +201,7 @@ function editResources() {
       const type = types.find(t => t.id === resource);
       if (type) type.color = newFill;
       Resources.updateTypes(types);
-      drawResources();
+      drawResources(Resources.getShowHidden());
     };
     openPicker(currentFill, callback);
   }
@@ -211,7 +212,7 @@ function editResources() {
     const type = types.find(t => t.id === resource);
     if (type) type.name = el.value;
     Resources.updateTypes(types);
-    drawResources();
+    drawResources(Resources.getShowHidden());
     updateFilters();
   }
 
@@ -249,7 +250,7 @@ function editResources() {
     const type = types.find(t => t.id === resource);
     if (type) type.icon = el.value;
     Resources.updateTypes(types);
-    drawResources();
+    drawResources(Resources.getShowHidden());
     updateFilters();
   }
 
@@ -257,7 +258,7 @@ function editResources() {
     const resource = +el.parentNode.dataset.id;
     if (el.checked) Resources.showType(resource);
     else Resources.hideType(resource);
-    drawResources();
+    drawResources(Resources.getShowHidden());
   }
 
   function removeCustomResource(el) {
@@ -265,18 +266,18 @@ function editResources() {
     const types = Resources.getTypes().filter(t => t.id !== resource);
     Resources.updateTypes(types);
     refreshResourcesEditor();
-    drawResources();
+    drawResources(Resources.getShowHidden());
     updateFilters();
   }
 
   byId("resourcesAdd").addEventListener("click", addCustomResource);
   byId("resourcesDisplaySize").addEventListener("change", () => {
     Resources.setDisplayMode(byId("resourcesDisplaySize").checked);
-    drawResources();
+    drawResources(Resources.getShowHidden());
   });
   byId("resourcesUseIcons").addEventListener("change", () => {
     Resources.setUseIcons(byId("resourcesUseIcons").checked);
-    drawResources();
+    drawResources(Resources.getShowHidden());
   });
   byId("resourcesFrequency").addEventListener("change", () => {
     const val = +byId("resourcesFrequency").value;
@@ -286,6 +287,10 @@ function editResources() {
     }
     Resources.setFrequency(val);
     regenerateResources();
+  });
+  byId("showHiddenResources").addEventListener("change", () => {
+    Resources.setShowHidden(byId("showHiddenResources").checked);
+    drawResources(Resources.getShowHidden());
   });
 
   function addCustomResource() {


### PR DESCRIPTION
## Summary
- support generation of hidden resource deposits
- reveal deposits to civs as they expand
- only draw visible deposits with optional debug overlay for hidden ones
- add UI checkbox to toggle display of undiscovered resources

## Testing
- `npm test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jest)*

------
https://chatgpt.com/codex/tasks/task_e_68817193fed883248c69ca82506a6384