### PR TITLE
Fix resource duplication during civ growth

### DIFF
--- a/modules/resources-generator.js
+++ b/modules/resources-generator.js
@@ -33,6 +33,7 @@ window.Resources = (function () {
   }
 
   async function generateHiddenResources() {
+    if (pack.hiddenResources?.length || pack.resources?.length) return; // already generated
     await loadConfig();
     const {cells} = pack;
     const tectonicMap = computeTectonicZones();
@@ -105,7 +106,7 @@ window.Resources = (function () {
           cells.visibleResource[c] = typeId;
           cells.visibleDeposit[c] = dep.i;
         });
-        resources.push(dep);
+        if (!resources.some(r => r.i === dep.i)) resources.push(dep);
       });
     }
     if (window.drawResources) drawResources(showHiddenResources);


### PR DESCRIPTION
## Summary
- prevent regenerating hidden resources if they already exist
- avoid pushing discovered deposits multiple times

## Testing
- `npm test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jest)*

------
https://chatgpt.com/codex/tasks/task_e_688179244edc8324b3bc326c46349ca5