### PR TITLE
Adjust resource generation frequency

### DIFF
--- a/modules/resources-generator.js
+++ b/modules/resources-generator.js
@@ -54,7 +54,7 @@ window.Resources = (function () {
       const weights = types.map(t => getResourceWeight(t, height, biome, pop, tectonic));
       const total = weights.reduce((a, b) => a + b, 0);
       const presence = regionRandom(cells.p[i][0], cells.p[i][1], "res_presence");
-      if (presence >= total) continue;
+      if (presence >= total * frequency) continue;
       let r = regionRandom(cells.p[i][0], cells.p[i][1], "res_type") * total;
       let resIndex = -1;
       for (let j = 0; j < weights.length; j++) {


### PR DESCRIPTION
## Summary
- apply frequency multiplier when checking resource presence

## Testing
- `npm test` *(fails: 403 Forbidden - registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_6881839fca8c8324b54f7f0f55c997f2