### PR TITLE
Introduce hidden resources with discovery

### DIFF
--- a/index.html
+++ b/index.html
@@ -4985,7 +4985,8 @@
           <button id="resourcesAdd" data-tip="Add a custom resource" class="icon-plus"></button>
           <label style="margin-left:5px"><input id="resourcesDisplaySize" type="checkbox"/>Display by size</label>
           <label style="margin-left:5px"><input id="resourcesUseIcons" type="checkbox" checked/>Use icons</label>
-          <label style="margin-left:5px">Frequency: <input id="resourcesFrequency" type="number" min="0" max="1" step="0.01" value="0.1" style="width:4em"></label>
+          <label style="margin-left:5px">Frequency: <input id="resourcesFrequency" type="number" min="0" max="1" step="0.01" value="0.05" style="width:4em"></label>
+          <label style="margin-left:5px"><input id="resourcesShowAll" type="checkbox"/>Show all</label>
           <div id="resourcesFilters" data-tip="Toggle resources visibility" style="display:none; margin-left:5px"></div>
         </div>
       </div>

--- a/main.js
+++ b/main.js
@@ -654,6 +654,7 @@ async function generate(options) {
     Cultures.generate();
     Cultures.expand();
     BurgsAndStates.generate();
+    Resources.discoverAroundBurgs();
     Routes.generate();
     Religions.generate();
     BurgsAndStates.defineStateForms();

--- a/modules/io/load.js
+++ b/modules/io/load.js
@@ -394,6 +394,15 @@ async function parseLoadedData(data, mapVersion) {
       pack.routes = data[37] ? JSON.parse(data[37]) : [];
       pack.zones = data[38] ? JSON.parse(data[38]) : [];
       pack.resources = data[39] ? JSON.parse(data[39]) : [];
+      pack.cells.resource = new Uint8Array(pack.cells.i.length);
+      pack.cells.hiddenResource = new Uint8Array(pack.cells.i.length);
+      pack.resources.forEach(r => {
+        const cellsArr = findAll(r.x, r.y, r.size);
+        cellsArr.forEach(c => {
+          pack.cells.hiddenResource[c] = r.type;
+          if (r.visible) pack.cells.resource[c] = r.type;
+        });
+      });
       pack.cells.biome = Uint8Array.from(data[16].split(","));
       pack.cells.burg = Uint16Array.from(data[17].split(","));
       pack.cells.conf = Uint8Array.from(data[18].split(","));

--- a/modules/renderers/draw-resources.js
+++ b/modules/renderers/draw-resources.js
@@ -9,6 +9,7 @@ function drawResources() {
   const tooltipSupported = !MOBILE && document.getElementById("tooltip");
 
   const html = pack.resources
+    .filter(r => r.visible)
     .filter(r => Resources.isTypeVisible(r.type))
     .map(r => {
       const type = Resources.getType(r.type);

--- a/modules/ui/resources-editor.js
+++ b/modules/ui/resources-editor.js
@@ -6,10 +6,13 @@ function editResources() {
 
   const body = byId("resourcesBody");
   const filters = byId("resourcesFilters");
+  const showAllCheckbox = byId("resourcesShowAll");
+  let showAll = false;
   refreshResourcesEditor();
   byId("resourcesDisplaySize").checked = Resources.getDisplayMode();
   byId("resourcesUseIcons").checked = Resources.getUseIcons();
   byId("resourcesFrequency").value = Resources.getFrequency();
+  showAllCheckbox.checked = showAll;
 
   if (modules.editResources) return;
   modules.editResources = true;
@@ -26,6 +29,10 @@ function editResources() {
   byId("resourcesEditStyle").addEventListener("click", () => editStyle("resources"));
   byId("resourcesLegend").addEventListener("click", toggleLegend);
   byId("resourcesRegenerate").addEventListener("click", regenerateResources);
+  showAllCheckbox.addEventListener("change", () => {
+    showAll = showAllCheckbox.checked;
+    refreshResourcesEditor();
+  });
   byId("resourcesManually").addEventListener("click", enterResourcesManualAssign);
   byId("resourcesManuallyApply").addEventListener("click", applyResourcesManualAssign);
   byId("resourcesManuallyCancel").addEventListener("click", exitResourcesManualAssign);
@@ -53,7 +60,7 @@ function editResources() {
     const types = Resources.getTypes();
     const counts = {};
     for (const i of cells.i) {
-      const id = cells.resource[i];
+      const id = showAll ? cells.hiddenResource[i] : cells.resource[i];
       if (id) counts[id] = (counts[id] || 0) + 1;
     }
     let lines = types


### PR DESCRIPTION
## Summary
- generate resources into `hiddenResource` and mark deposits as initially invisible
- expose new discovery helpers to reveal deposits around burgs
- draw only visible deposits on the Resources layer
- rebuild resource arrays on load
- update main map generation to discover deposits near burgs
- add editor option to show hidden resources
- default resource frequency lowered to 50%

## Testing
- `npm test` *(fails: 403 Forbidden when fetching packages)*

------
https://chatgpt.com/codex/tasks/task_e_6881b6039e488324806a40d7533cca39