### PR TITLE
Fix resource visibility after regeneration

### DIFF
--- a/modules/ui/resources-editor.js
+++ b/modules/ui/resources-editor.js
@@ -119,7 +119,10 @@ function editResources() {
   }
 
   function regenerateResources() {
-    Resources.regenerate().then(refreshResourcesEditor);
+    Resources.regenerate().then(() => {
+      Resources.discoverAroundBurgs();
+      refreshResourcesEditor();
+    });
   }
 
   function enterResourcesManualAssign() {


### PR DESCRIPTION
## Summary
- ensure resources discovered around burgs after regenerating

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run lint`
- `npm run format`
- `npm test` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6881ba79943883249d789c30345c181b