### PR TITLE
Fix resource toggle and layout

### DIFF
--- a/index.css
+++ b/index.css
@@ -1827,6 +1827,11 @@ div.editorLine {
   margin: 6px 0 0 6px;
 }
 
+#resourcesBottom,
+#resourcesOptions {
+  margin: 6px 0 0 6px;
+}
+
 #unitsBody label {
   display: inline-block;
   width: 9em;

--- a/index.html
+++ b/index.html
@@ -4963,12 +4963,6 @@
 
         <div id="resourcesBody" class="table"></div>
 
-        <div id="resourcesFooter" class="totalLine">
-          <div data-tip="Total resources placed" style="margin-left: 5px">
-            Spots:&nbsp;<span id="resourcesFooterNumber">0</span>
-          </div>
-        </div>
-
         <div id="resourcesBottom">
           <button id="resourcesEditorRefresh" data-tip="Refresh the Editor" class="icon-cw"></button>
           <button id="resourcesEditStyle" data-tip="Edit resources style in Style Editor" class="icon-adjust"></button>
@@ -4983,11 +4977,20 @@
           </div>
           <button id="resourcesRegenerate" data-tip="Regenerate resources" class="icon-arrows-cw"></button>
           <button id="resourcesAdd" data-tip="Add a custom resource" class="icon-plus"></button>
+        </div>
+
+        <div id="resourcesOptions">
           <label style="margin-left:5px"><input id="resourcesDisplaySize" type="checkbox"/>Display by size</label>
           <label style="margin-left:5px"><input id="resourcesUseIcons" type="checkbox" checked/>Use icons</label>
           <label style="margin-left:5px">Frequency: <input id="resourcesFrequency" type="number" min="0" max="1" step="0.01" value="0.05" style="width:4em"></label>
           <label style="margin-left:5px"><input id="resourcesShowAll" type="checkbox"/>Show all</label>
           <div id="resourcesFilters" data-tip="Toggle resources visibility" style="display:none; margin-left:5px"></div>
+        </div>
+
+        <div id="resourcesFooter" class="totalLine">
+          <div data-tip="Total resources placed" style="margin-left: 5px">
+            Spots:&nbsp;<span id="resourcesFooterNumber">0</span>
+          </div>
         </div>
       </div>
 

--- a/modules/renderers/draw-resources.js
+++ b/modules/renderers/draw-resources.js
@@ -1,6 +1,6 @@
 "use strict";
 
-function drawResources() {
+function drawResources(showHidden = false) {
   TIME && console.time("drawResources");
   resources.selectAll("*").remove();
 
@@ -9,7 +9,7 @@ function drawResources() {
   const tooltipSupported = !MOBILE && document.getElementById("tooltip");
 
   const html = pack.resources
-    .filter(r => r.visible)
+    .filter(r => showHidden || r.visible)
     .filter(r => Resources.isTypeVisible(r.type))
     .map(r => {
       const type = Resources.getType(r.type);

--- a/modules/ui/resources-editor.js
+++ b/modules/ui/resources-editor.js
@@ -9,6 +9,7 @@ function editResources() {
   const showAllCheckbox = byId("resourcesShowAll");
   let showAll = false;
   refreshResourcesEditor();
+  drawResources(showAll);
   byId("resourcesDisplaySize").checked = Resources.getDisplayMode();
   byId("resourcesUseIcons").checked = Resources.getUseIcons();
   byId("resourcesFrequency").value = Resources.getFrequency();
@@ -32,6 +33,7 @@ function editResources() {
   showAllCheckbox.addEventListener("change", () => {
     showAll = showAllCheckbox.checked;
     refreshResourcesEditor();
+    drawResources(showAll);
   });
   byId("resourcesManually").addEventListener("click", enterResourcesManualAssign);
   byId("resourcesManuallyApply").addEventListener("click", applyResourcesManualAssign);
@@ -88,11 +90,12 @@ function editResources() {
              `<input class="resourceBase" type="number" step="0.001" value="0" style="width:4em"/>`+
              `<input class="resourceSize" type="number" step="1" min="1" value="1" style="width:4em"/>`+
              `<div class="resourceCells">0</div></div>`;
-    body.innerHTML = lines;
-    body.querySelector("div.states")?.classList.add("selected");
-    byId("resourcesFooterNumber").textContent = pack.resources.length;
-    updateFilters();
-  }
+  body.innerHTML = lines;
+  body.querySelector("div.states")?.classList.add("selected");
+  byId("resourcesFooterNumber").textContent = pack.resources.length;
+  updateFilters();
+  drawResources(showAll);
+}
 
   function updateFilters() {
     body.querySelectorAll("div.states.resources").forEach(line => {
@@ -122,6 +125,7 @@ function editResources() {
     Resources.regenerate().then(() => {
       Resources.discoverAroundBurgs();
       refreshResourcesEditor();
+      drawResources(showAll);
     });
   }
 
@@ -180,7 +184,7 @@ function editResources() {
         pack.resources.push({i: id, type: typeId, x: rn(x,2), y: rn(y,2), cell: i, size, tons});
       }
     });
-    drawResources();
+    drawResources(showAll);
   }
 
   function applyResourcesManualAssign() {
@@ -210,7 +214,7 @@ function editResources() {
       const type = types.find(t => t.id === resource);
       if (type) type.color = newFill;
       Resources.updateTypes(types);
-      drawResources();
+      drawResources(showAll);
     };
     openPicker(currentFill, callback);
   }
@@ -221,7 +225,7 @@ function editResources() {
     const type = types.find(t => t.id === resource);
     if (type) type.name = el.value;
     Resources.updateTypes(types);
-    drawResources();
+    drawResources(showAll);
     updateFilters();
   }
 
@@ -259,7 +263,7 @@ function editResources() {
     const type = types.find(t => t.id === resource);
     if (type) type.icon = el.value;
     Resources.updateTypes(types);
-    drawResources();
+    drawResources(showAll);
     updateFilters();
   }
 
@@ -267,7 +271,7 @@ function editResources() {
     const resource = +el.parentNode.dataset.id;
     if (el.checked) Resources.showType(resource);
     else Resources.hideType(resource);
-    drawResources();
+    drawResources(showAll);
   }
 
   function removeCustomResource(el) {
@@ -275,18 +279,18 @@ function editResources() {
     const types = Resources.getTypes().filter(t => t.id !== resource);
     Resources.updateTypes(types);
     refreshResourcesEditor();
-    drawResources();
+    drawResources(showAll);
     updateFilters();
   }
 
   byId("resourcesAdd").addEventListener("click", addCustomResource);
   byId("resourcesDisplaySize").addEventListener("change", () => {
     Resources.setDisplayMode(byId("resourcesDisplaySize").checked);
-    drawResources();
+    drawResources(showAll);
   });
   byId("resourcesUseIcons").addEventListener("change", () => {
     Resources.setUseIcons(byId("resourcesUseIcons").checked);
-    drawResources();
+    drawResources(showAll);
   });
   byId("resourcesFrequency").addEventListener("change", () => {
     const val = +byId("resourcesFrequency").value;


### PR DESCRIPTION
## Summary
- adjust resources editor bottom layout so text options sit on a separate row
- style new options row
- allow drawResources to reveal hidden spots when `Show all` is enabled
- update resources editor to pass the option through

## Testing
- `npm run lint`
- `npm test` *(fails: 403 Forbidden when trying to fetch jest)*

------
https://chatgpt.com/codex/tasks/task_e_6881f146248483249dd5cfee499b6a6f