### PR TITLE
Add tooltips to resource editor buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -4964,22 +4964,22 @@
         <div id="resourcesBody" class="table"></div>
 
         <div id="resourcesBottom">
-          <button id="resourcesEditorRefresh" data-tip="Refresh the Editor" class="icon-cw"></button>
-          <button id="resourcesEditStyle" data-tip="Edit resources style in Style Editor" class="icon-adjust"></button>
-          <button id="resourcesLegend" data-tip="Toggle Legend box" class="icon-list-bullet"></button>
-          <button id="resourcesDisplaySize" data-tip="Display by size" class="icon-ruler"></button>
-          <button id="resourcesUseIcons" data-tip="Use icons" class="icon-layer-group"></button>
-          <button id="resourcesShowAll" data-tip="Show all resources" class="icon-eye-off"></button>
-          <button id="resourcesManually" data-tip="Manually re-assign resources" class="icon-brush"></button>
+          <button id="resourcesEditorRefresh" data-tip="Refresh the Editor" title="Refresh the Editor" class="icon-cw"></button>
+          <button id="resourcesEditStyle" data-tip="Edit resources style in Style Editor" title="Edit resources style in Style Editor" class="icon-adjust"></button>
+          <button id="resourcesLegend" data-tip="Toggle Legend box" title="Toggle Legend box" class="icon-list-bullet"></button>
+          <button id="resourcesDisplaySize" data-tip="Display by size" title="Display by size" class="icon-ruler"></button>
+          <button id="resourcesUseIcons" data-tip="Use icons" title="Use icons" class="icon-layer-group"></button>
+          <button id="resourcesShowAll" data-tip="Show all resources" title="Show all resources" class="icon-eye-off"></button>
+          <button id="resourcesManually" data-tip="Manually re-assign resources" title="Manually re-assign resources" class="icon-brush"></button>
           <div id="resourcesManuallyButtons" style="display: none">
             <div data-tip="Change brush size" style="margin-block: 0.3em">
               Brush size: <slider-input id="resourcesBrush" min="1" max="100" value="15"></slider-input>
             </div>
-            <button id="resourcesManuallyApply" data-tip="Apply assignment" class="icon-check"></button>
-            <button id="resourcesManuallyCancel" data-tip="Cancel assignment" class="icon-cancel"></button>
+            <button id="resourcesManuallyApply" data-tip="Apply assignment" title="Apply assignment" class="icon-check"></button>
+            <button id="resourcesManuallyCancel" data-tip="Cancel assignment" title="Cancel assignment" class="icon-cancel"></button>
           </div>
-          <button id="resourcesRegenerate" data-tip="Regenerate resources" class="icon-arrows-cw"></button>
-          <button id="resourcesAdd" data-tip="Add a custom resource" class="icon-plus"></button>
+          <button id="resourcesRegenerate" data-tip="Regenerate resources" title="Regenerate resources" class="icon-arrows-cw"></button>
+          <button id="resourcesAdd" data-tip="Add a custom resource" title="Add a custom resource" class="icon-plus"></button>
         </div>
 
         <div id="resourcesOptions">


### PR DESCRIPTION
## Summary
- improve resource editor button usability by adding `title` attributes

## Testing
- `npm test` *(fails: 403 Forbidden accessing npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_68840cbf081c83248358bdfef5567602