### PR TITLE
Add growth expansion show

### DIFF
--- a/index.html
+++ b/index.html
@@ -1716,6 +1716,15 @@
               </td>
             </tr>
 
+            <tr data-tip="Animate states growth on generation">
+              <td></td>
+              <td>Growth show</td>
+              <td colspan="2">
+                <input type="checkbox" id="showGrowth" />
+                <slider-input id="growthShowSpeed" min="0" max="100" value="100"></slider-input>
+              </td>
+            </tr>
+
             <tr data-tip="Define a number of towns to be placed (if enough suitable land exists)">
               <td>
                 <i data-locked="0" id="lock_manors" class="icon-lock-open"></i>
@@ -8214,10 +8223,20 @@
     <script defer src="modules/ui/battle-screen.js?v=1.108.5"></script>
     <script defer src="modules/ui/emblems-editor.js?v=1.99.00"></script>
     <script defer src="modules/ui/markers-editor.js?v=1.108.5"></script>
+    <div id="growthControls" class="dialog" style="display:none; position: absolute; left: 10px; bottom: 10px;">
+      <button id="growthPlayBtn">Play</button>
+      <button id="growthPauseBtn">Pause</button>
+      <button id="growthBackBtn">Step -</button>
+      <button id="growthForwardBtn">Step +</button>
+      <button id="growthRewindBtn">Rewind</button>
+      <button id="growthRefreshBtn">Refresh</button>
+      <button id="growthRegenerateBtn">Regenerate</button>
+    </div>
     <script defer src="modules/ui/3d.js?v=1.99.00"></script>
     <script defer src="modules/ui/submap-tool.js?v=1.106.2"></script>
     <script defer src="modules/ui/transform-tool.js?v=1.106.2"></script>
     <script defer src="modules/ui/hotkeys.js?v=1.104.0"></script>
+    <script defer src="modules/ui/growth-show.js"></script>
     <script defer src="modules/coa-renderer.js?v=1.99.00"></script>
     <script defer src="libs/rgbquant.min.js"></script>
     <script defer src="libs/jquery.ui.touch-punch.min.js"></script>

--- a/main.js
+++ b/main.js
@@ -653,7 +653,7 @@ async function generate(options) {
     rankCells();
     Cultures.generate();
     Cultures.expand();
-    BurgsAndStates.generate();
+    const {growthSteps} = BurgsAndStates.generate({showGrowth: byId("showGrowth")?.checked});
     Resources.discoverAroundBurgs();
     Routes.generate();
     Religions.generate();
@@ -674,6 +674,12 @@ async function generate(options) {
 
     WARN && console.warn(`TOTAL: ${rn((performance.now() - timeStart) / 1000, 2)}s`);
     showStatistics();
+    if (byId("showGrowth")?.checked) {
+      byId("growthControls").style.display = "block";
+      GrowthShowUI.start(growthSteps);
+    } else {
+      byId("growthControls").style.display = "none";
+    }
     INFO && console.groupEnd("Generated Map " + seed);
   } catch (error) {
     ERROR && console.error(error);

--- a/modules/ui/growth-show.js
+++ b/modules/ui/growth-show.js
@@ -1,0 +1,116 @@
+"use strict";
+
+window.GrowthShowUI = (() => {
+  let steps = [];
+  let index = 0;
+  let timer = null;
+
+  const playBtn = byId("growthPlayBtn");
+  const pauseBtn = byId("growthPauseBtn");
+  const backBtn = byId("growthBackBtn");
+  const forwardBtn = byId("growthForwardBtn");
+  const rewindBtn = byId("growthRewindBtn");
+  const refreshBtn = byId("growthRefreshBtn");
+  const regenerateBtn = byId("growthRegenerateBtn");
+  const speedSlider = byId("growthShowSpeed");
+
+  function interval() {
+    const val = speedSlider ? speedSlider.valueAsNumber : 100;
+    const total = 30 - (val / 100) * (30 - 0.1);
+    return steps.length ? (total * 1000) / steps.length : 0;
+  }
+
+  function applyStep(i, forward = true) {
+    const step = steps[i];
+    if (!step) return;
+    pack.cells.state[step.cell] = forward ? step.to : step.from;
+  }
+
+  function draw() {
+    if (layerIsOn("toggleStates")) drawStates();
+  }
+
+  function frame() {
+    if (index >= steps.length) {
+      pause();
+      return;
+    }
+    applyStep(index, true);
+    index++;
+    draw();
+  }
+
+  function play() {
+    pause();
+    timer = setInterval(frame, Math.max(10, interval()));
+  }
+
+  function pause() {
+    if (timer) clearInterval(timer);
+    timer = null;
+  }
+
+  function rewind() {
+    pause();
+    while (index > 0) {
+      index--;
+      applyStep(index, false);
+    }
+    draw();
+  }
+
+  function stepForward() {
+    pause();
+    if (index < steps.length) {
+      applyStep(index, true);
+      index++;
+      draw();
+    }
+  }
+
+  function stepBackward() {
+    pause();
+    if (index > 0) {
+      index--;
+      applyStep(index, false);
+      draw();
+    }
+  }
+
+  function refresh() {
+    rewind();
+    play();
+  }
+
+  function regenerate() {
+    pause();
+    steps = BurgsAndStates.expandStatesWithSteps();
+    index = 0;
+    draw();
+    play();
+  }
+
+  function init() {
+    playBtn?.on("click", play);
+    pauseBtn?.on("click", pause);
+    backBtn?.on("click", stepBackward);
+    forwardBtn?.on("click", stepForward);
+    rewindBtn?.on("click", rewind);
+    refreshBtn?.on("click", refresh);
+    regenerateBtn?.on("click", regenerate);
+    speedSlider?.addEventListener("input", () => {
+      if (timer) play();
+    });
+  }
+
+  function start(growthSteps) {
+    steps = growthSteps || [];
+    index = 0;
+    draw();
+    if (steps.length) play();
+  }
+
+  return {init, start};
+})();
+
+document.addEventListener("DOMContentLoaded", () => GrowthShowUI.init());


### PR DESCRIPTION
## Summary
- add `expandStatesWithSteps` to record state expansion progress
- integrate new `GrowthShowUI` controls for playback
- expose a new `Growth show` option and speed slider in HTML
- trigger playback when generating if enabled

## Testing
- `npm test` *(fails: 403 Forbidden)*
- `npm run lint` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68844db1eff48324bff86b375234ee1a