### PR TITLE
Add fixed overlay for civ player controls

### DIFF
--- a/index.css
+++ b/index.css
@@ -2021,6 +2021,19 @@ div.textual span,
   box-shadow: 2px 2px 5px -3px #3a2804;
 }
 
+#civPlayerControls {
+  display: none;
+  position: fixed;
+  width: 28vw;
+  left: 1vw;
+  bottom: 1vw;
+  font-size: 1.2em;
+  border: 1px solid #5e4fa2;
+  background: rgba(255, 250, 228, 0.7);
+  box-shadow: 2px 2px 5px -3px #3a2804;
+  z-index: 1000;
+}
+
 @media screen and (max-width: 600px) {
   #notes {
     width: 50vw;

--- a/index.html
+++ b/index.html
@@ -6280,6 +6280,7 @@
     ></div>
 
     <div id="mapOverlay" style="display: none">Drop a map file to open</div>
+    <div id="civPlayerControls"></div>
 
     <div id="fileInputs" style="display: none">
       <input type="file" accept=".map,.gz" id="mapToLoad" />


### PR DESCRIPTION
## Summary
- add `#civPlayerControls` container after `mapOverlay` in index.html
- style new overlay in index.css to appear fixed in the lower left

## Testing
- `npm test` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68845cbf9a408324a0aa936c09d5113e