### PR TITLE
Add civ player controls overlay

### DIFF
--- a/index.css
+++ b/index.css
@@ -2022,7 +2022,7 @@ div.textual span,
 }
 
 #civPlayerControls {
-  display: none;
+  display: block;
   position: fixed;
   width: 28vw;
   left: 1vw;

--- a/index.html
+++ b/index.html
@@ -6280,7 +6280,12 @@
     ></div>
 
     <div id="mapOverlay" style="display: none">Drop a map file to open</div>
-    <div id="civPlayerControls"></div>
+    <div id="civPlayerControls">
+      <button id="civPlayBtn">Play</button>
+      <button id="civPauseBtn">Pause</button>
+      <button id="civStepBackBtn">Step -</button>
+      <button id="civStepForwardBtn">Step +</button>
+    </div>
 
     <div id="fileInputs" style="display: none">
       <input type="file" accept=".map,.gz" id="mapToLoad" />
@@ -8238,6 +8243,7 @@
     <script defer src="modules/ui/transform-tool.js?v=1.106.2"></script>
     <script defer src="modules/ui/hotkeys.js?v=1.104.0"></script>
     <script defer src="modules/ui/growth-show.js"></script>
+    <script defer src="modules/ui/civ-player-controls.js"></script>
     <script defer src="modules/coa-renderer.js?v=1.99.00"></script>
     <script defer src="libs/rgbquant.min.js"></script>
     <script defer src="libs/jquery.ui.touch-punch.min.js"></script>

--- a/modules/ui/civ-player-controls.js
+++ b/modules/ui/civ-player-controls.js
@@ -1,0 +1,19 @@
+"use strict";
+
+window.CivPlayerControls = (() => {
+  function init() {
+    const container = document.getElementById("civPlayerControls");
+    if (!container) return;
+    container.innerHTML = `
+      <button id="civPlayBtn">Play</button>
+      <button id="civPauseBtn">Pause</button>
+      <button id="civStepBackBtn">Step -</button>
+      <button id="civStepForwardBtn">Step +</button>
+    `;
+    container.style.display = "block";
+  }
+
+  return {init};
+})();
+
+document.addEventListener("DOMContentLoaded", () => CivPlayerControls.init());


### PR DESCRIPTION
## Summary
- show civilization generation controls on page
- add simple script to populate controls
- ensure civ player controls are displayed

## Testing
- `npm test` *(fails: 403 Forbidden to registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_688468ead0748324bd54908879ea24ad