### PR TITLE
Add functional civilization growth player

### DIFF
--- a/main.js
+++ b/main.js
@@ -680,6 +680,7 @@ async function generate(options) {
     } else {
       byId("growthControls").style.display = "none";
     }
+    CivPlayerControls.start(growthSteps);
     INFO && console.groupEnd("Generated Map " + seed);
   } catch (error) {
     ERROR && console.error(error);

--- a/modules/ui/civ-player-controls.js
+++ b/modules/ui/civ-player-controls.js
@@ -1,6 +1,9 @@
 'use strict';
 
 window.CivPlayerControls = (() => {
+  let steps = [];
+  let index = 0;
+  let timer = null;
   let playing = false;
 
   function showLayer() {
@@ -9,14 +12,18 @@ window.CivPlayerControls = (() => {
 
   function play() {
     showLayer();
+    pause();
     playing = true;
     const btn = byId('civPlayPauseBtn');
     btn.classList.remove('icon-play');
     btn.classList.add('icon-pause');
+    timer = setInterval(frame, Math.max(10, interval()));
   }
 
   function pause() {
     playing = false;
+    if (timer) clearInterval(timer);
+    timer = null;
     const btn = byId('civPlayPauseBtn');
     btn.classList.remove('icon-pause');
     btn.classList.add('icon-play');
@@ -24,6 +31,79 @@ window.CivPlayerControls = (() => {
 
   function togglePlay() {
     playing ? pause() : play();
+  }
+
+  function interval() {
+    const slider = byId('civSpeed');
+    const val = slider ? slider.valueAsNumber : 50;
+    const total = 30 - (val / 100) * (30 - 0.1);
+    return steps.length ? (total * 1000) / steps.length : 0;
+  }
+
+  function applyStep(i, forward = true) {
+    const step = steps[i];
+    if (!step) return;
+    pack.cells.state[step.cell] = forward ? step.to : step.from;
+  }
+
+  function draw() {
+    if (layerIsOn('toggleStates')) drawStates();
+  }
+
+  function frame() {
+    if (index >= steps.length) {
+      pause();
+      return;
+    }
+    applyStep(index, true);
+    index++;
+    draw();
+  }
+
+  function start(growthSteps) {
+    steps = growthSteps || [];
+    index = 0;
+    draw();
+  }
+
+  function rewind() {
+    pause();
+    while (index > 0) {
+      index--;
+      applyStep(index, false);
+    }
+    draw();
+  }
+
+  function stepForward() {
+    pause();
+    if (index < steps.length) {
+      applyStep(index, true);
+      index++;
+      draw();
+    }
+  }
+
+  function stepBackward() {
+    pause();
+    if (index > 0) {
+      index--;
+      applyStep(index, false);
+      draw();
+    }
+  }
+
+  function refresh() {
+    rewind();
+    play();
+  }
+
+  function regenerate() {
+    pause();
+    steps = BurgsAndStates.expandStatesWithSteps();
+    index = 0;
+    draw();
+    play();
   }
 
   function init() {
@@ -39,9 +119,16 @@ window.CivPlayerControls = (() => {
     `;
     container.style.display = 'block';
     byId('civPlayPauseBtn').on('click', togglePlay);
+    byId('civStepBackBtn').on('click', stepBackward);
+    byId('civStepForwardBtn').on('click', stepForward);
+    byId('civReplayBtn').on('click', refresh);
+    byId('civRegenerateBtn').on('click', regenerate);
+    byId('civSpeed')?.addEventListener('input', () => {
+      if (timer) play();
+    });
   }
 
-  return { init, play, pause, togglePlay };
+  return { init, play, pause, togglePlay, start };
 })();
 
 document.addEventListener('DOMContentLoaded', () => CivPlayerControls.init());


### PR DESCRIPTION
## Summary
- animate civilization growth steps via new player controls
- hook player into map generation

## Testing
- `npm run lint`
- `npm test` *(fails: 403 Forbidden to registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_68856e8002808324ba031674f1352de7