### PR TITLE
Toggle editor dialogs on repeated button clicks

### DIFF
--- a/modules/ui/biomes-editor.js
+++ b/modules/ui/biomes-editor.js
@@ -12,9 +12,6 @@ function editBiomes() {
   const animate = d3.transition().duration(2000).ease(d3.easeSinIn);
   refreshBiomesEditor();
 
-  if (modules.editBiomes) return;
-  modules.editBiomes = true;
-
   $("#biomesEditor").dialog({
     title: "Biomes Editor",
     resizable: false,
@@ -22,6 +19,9 @@ function editBiomes() {
     close: closeBiomesEditor,
     position: {my: "right top", at: "right-10 top+10", of: "svg"}
   });
+
+  if (modules.editBiomes) return;
+  modules.editBiomes = true;
 
   // add listeners
   document.getElementById("biomesEditorRefresh").addEventListener("click", refreshBiomesEditor);

--- a/modules/ui/diplomacy-editor.js
+++ b/modules/ui/diplomacy-editor.js
@@ -57,9 +57,6 @@ function editDiplomacy() {
   refreshDiplomacyEditor();
   viewbox.style("cursor", "crosshair").on("click", selectStateOnMapClick);
 
-  if (modules.editDiplomacy) return;
-  modules.editDiplomacy = true;
-
   $("#diplomacyEditor").dialog({
     title: "Diplomacy Editor",
     resizable: false,
@@ -67,6 +64,9 @@ function editDiplomacy() {
     close: closeDiplomacyEditor,
     position: {my: "right top", at: "right-10 top+10", of: "svg", collision: "fit"}
   });
+
+  if (modules.editDiplomacy) return;
+  modules.editDiplomacy = true;
 
   // add listeners
   document.getElementById("diplomacyEditorRefresh").addEventListener("click", refreshDiplomacyEditor);

--- a/modules/ui/provinces-editor.js
+++ b/modules/ui/provinces-editor.js
@@ -11,9 +11,6 @@ function editProvinces() {
   const body = byId("provincesBodySection");
   refreshProvincesEditor();
 
-  if (modules.editProvinces) return;
-  modules.editProvinces = true;
-
   $("#provincesEditor").dialog({
     title: "Provinces Editor",
     resizable: false,
@@ -21,6 +18,9 @@ function editProvinces() {
     close: closeProvincesEditor,
     position: {my: "right top", at: "right-10 top+10", of: "svg", collision: "fit"}
   });
+
+  if (modules.editProvinces) return;
+  modules.editProvinces = true;
 
   // add listeners
   byId("provincesEditorRefresh").on("click", refreshProvincesEditor);

--- a/modules/ui/resources-editor.js
+++ b/modules/ui/resources-editor.js
@@ -17,9 +17,6 @@ function editResources() {
   byId("resourcesFrequency").value = Resources.getFrequency();
   if (showAll) showAllButton.classList.add("pressed");
 
-  if (modules.editResources) return;
-  modules.editResources = true;
-
   $("#resourcesEditor").dialog({
     title: "Resources Editor",
     resizable: false,
@@ -27,6 +24,9 @@ function editResources() {
     position: {my: "right top", at: "right-10 top+10", of: "svg", collision: "fit"},
     close: closeResourcesEditor
   });
+
+  if (modules.editResources) return;
+  modules.editResources = true;
 
   byId("resourcesEditorRefresh").addEventListener("click", refreshResourcesEditor);
   byId("resourcesEditStyle").addEventListener("click", () => editStyle("resources"));

--- a/modules/ui/tools.js
+++ b/modules/ui/tools.js
@@ -1,11 +1,49 @@
 "use strict";
 
+// mapping of buttons to dialogs for toggle behavior
+const buttonDialogMap = {
+  editBiomesButton: "#biomesEditor",
+  overviewBurgsButton: "#burgsOverview",
+  editCulturesButton: "#culturesEditor",
+  editDiplomacyButton: "#diplomacyEditor",
+  editEmblemButton: "#emblemEditor",
+  overviewMarkersButton: "#markersOverview",
+  editResourcesButton: "#resourcesEditor",
+  overviewMilitaryButton: "#militaryOverview",
+  editNamesBaseButton: "#namesbaseEditor",
+  editNotesButton: "#notesEditor",
+  editProvincesButton: "#provincesEditor",
+  editReligions: "#religionsEditor",
+  overviewRiversButton: "#riversOverview",
+  overviewRoutesButton: "#routesOverview",
+  editStatesButton: "#statesEditor",
+  editUnitsButton: "#unitsEditor",
+  editZonesButton: "#zonesEditor",
+  overviewCellsButton: "#cellInfo",
+  overviewChartsButton: "#chartsOverview",
+  addRoute: "#routeCreator",
+  openSubmapTool: "#submapTool",
+  openTransformTool: "#transformTool"
+};
+
 // module to control the Tools options (click to edit, to re-geenerate, tp add)
 
 toolsContent.addEventListener("click", function (event) {
   if (customization) return tip("Please exit the customization mode first", false, "error");
   if (!["BUTTON", "I"].includes(event.target.tagName)) return;
   const button = event.target.id;
+
+  // close dialog if it's already open
+  const selector = buttonDialogMap[button];
+  if (selector && $(selector).is(":visible")) {
+    $(selector).dialog("close");
+    return;
+  }
+
+  if (button === "editHeightmapButton" && customization === 1) {
+    document.getElementById("finalizeHeightmap").click();
+    return;
+  }
 
   // click on open Editor buttons
   if (button === "editHeightmapButton") editHeightmap();
@@ -641,7 +679,9 @@ function addLabelOnClick() {
 }
 
 function toggleAddBurg() {
+  const pressed = byId("addBurgTool").classList.contains("pressed");
   unpressClickToAddButton();
+  if (pressed) return;
   byId("addBurgTool").classList.add("pressed");
   overviewBurgs();
   byId("addNewBurg").click();

--- a/modules/ui/units-editor.js
+++ b/modules/ui/units-editor.js
@@ -3,13 +3,13 @@ function editUnits() {
   closeDialogs("#unitsEditor, .stable");
   $("#unitsEditor").dialog();
 
-  if (modules.editUnits) return;
-  modules.editUnits = true;
-
   $("#unitsEditor").dialog({
     title: "Units Editor",
     position: {my: "right top", at: "right-10 top+10", of: "svg", collision: "fit"}
   });
+
+  if (modules.editUnits) return;
+  modules.editUnits = true;
 
   const renderScaleBar = () => {
     drawScaleBar(scaleBar, scale);

--- a/modules/ui/zones-editor.js
+++ b/modules/ui/zones-editor.js
@@ -8,15 +8,15 @@ function editZones() {
   updateFilters();
   zonesEditorAddLines();
 
-  if (modules.editZones) return;
-  modules.editZones = true;
-
   $("#zonesEditor").dialog({
     title: "Zones Editor",
     resizable: false,
     close: () => exitZonesManualAssignment("close"),
     position: {my: "right top", at: "right-10 top+10", of: "svg", collision: "fit"}
   });
+
+  if (modules.editZones) return;
+  modules.editZones = true;
 
   // add listeners
   byId("zonesFilterType").on("click", updateFilters);


### PR DESCRIPTION
## Summary
- allow repeated clicks on tool buttons to close the corresponding dialog
- adjust add-burg toggle behaviour
- keep editor initialization single-run while letting dialogs reopen

## Testing
- `npm test` *(fails: 403 Forbidden)*
- `npm run lint` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6885b5aefbc883249a4fb31c1f19bb4c