### PR TITLE
Add marker-resource linkage

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,4 @@ _Inspiration:_
 - Scott Turner's [_Here Dragons Abound_](https://heredragonsabound.blogspot.com)
 
 ***Praesmeodymium added a resources layer and hooked it into civilization generation with some advantages during the growth, not fully tested for balance, or a lot of other things. Resource editor shows undiscovered/unused resources as well as an editor for placing/removing and custom resources. not all rescource data is exposed in the editor yet. ***
+- Certain markers like sacred forests now automatically spawn hidden resource deposits.

--- a/modules/markers-generator.js
+++ b/modules/markers-generator.js
@@ -3,6 +3,11 @@
 window.Markers = (function () {
   let config = getDefaultConfig();
   let occupied = [];
+  const resourceByMarker = {
+    "sacred-forests": 13,
+    "sacred-pineries": 13,
+    "sacred-palm-groves": 13
+  };
 
   function getDefaultConfig() {
     const culturesSet = document.getElementById("culturesSet").value;
@@ -157,6 +162,10 @@ window.Markers = (function () {
     marker = {...base, x, y, ...marker, i};
     pack.markers.push(marker);
     occupied[marker.cell] = true;
+    const resId = resourceByMarker[marker.type];
+    if (resId && window.Resources?.addDeposit) {
+      Resources.addDeposit(resId, marker.cell);
+    }
     return marker;
   }
 

--- a/modules/resources-generator.js
+++ b/modules/resources-generator.js
@@ -31,6 +31,21 @@ window.Resources = (function () {
     return getDepositSize(type.name, r);
   }
 
+  function addDeposit(typeId, cell) {
+    const type = getType(typeId);
+    if (!type) return;
+    const [x, y] = pack.cells.p[cell];
+    const size = getRandomSize(type, x, y);
+    const tons = getDepositTons(type, x, y);
+    const affected = size > 1 ? findAll(x, y, size) : [cell];
+    affected.forEach(c => {
+      if (pack.cells.h[c] < 20) return;
+      pack.cells.hiddenResource[c] = typeId;
+    });
+    const id = (last(pack.resources)?.i || 0) + 1;
+    pack.resources.push({i: id, type: typeId, x: rn(x,2), y: rn(y,2), cell, size, tons, visible: false});
+  }
+
   async function loadConfig() {
     if (types.length) return types;
     const stored = JSON.safeParse(localStorage.getItem(STORAGE_KEY));
@@ -236,6 +251,7 @@ window.Resources = (function () {
     isTypeVisible,
     getHidden,
     discoverAroundBurgs,
+    addDeposit,
     discoverDeposit,
     getRandomSize,
     getDepositTons,

--- a/tests/markerResourceLink.test.js
+++ b/tests/markerResourceLink.test.js
@@ -1,0 +1,35 @@
+const path = require('path');
+
+test('adding marker with resource adds deposit', () => {
+  global.window = {};
+  global.document = { getElementById: () => ({ value: '' }) };
+  global.notes = [];
+  global.seed = 'test';
+  global.aleaPRNG = () => Math.random; // deterministic not required
+  global.findAll = () => [0];
+  global.rn = (v, d = 0) => { const m = Math.pow(10, d); return Math.round(v*m)/m; };
+  global.last = arr => arr[arr.length - 1];
+  global.Names = { getCulture: () => 'Test' };
+
+  global.pack = {
+    markers: [],
+    resources: [],
+    cells: {
+      i: [0],
+      p: [[0,0]],
+      h: [30],
+      culture: [0],
+      religion: [0],
+      hiddenResource: new Uint8Array(1)
+    },
+    religions: { 0: { name: 'Rel' } }
+  };
+
+  require('../modules/resources-generator.js');
+  require('../modules/markers-generator.js');
+
+  window.Markers.add({type: 'sacred-forests', cell: 0});
+
+  expect(pack.resources.length).toBe(1);
+  expect(pack.cells.hiddenResource[0]).toBe(13);
+});


### PR DESCRIPTION
## Summary
- link sacred forest markers to the Magical Timbers resource (id 13)
- automatically add a resource deposit when those markers are created
- expose `Resources.addDeposit` helper mirroring deposit generation
- test marker-resource linkage logic
- document automatic resource deposits from markers

## Testing
- `npm test` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6885c658053c8324bbc09102e1271c19