### PR TITLE
Make marker deposits visible and remove hidden

### DIFF
--- a/modules/markers-generator.js
+++ b/modules/markers-generator.js
@@ -164,7 +164,10 @@ window.Markers = (function () {
     occupied[marker.cell] = true;
     const resId = resourceByMarker[marker.type];
     if (resId && window.Resources?.addDeposit) {
-      Resources.addDeposit(resId, marker.cell);
+      const deposit = Resources.addDeposit(resId, marker.cell, true);
+      if (deposit && Resources.removeHiddenDeposit) {
+        Resources.removeHiddenDeposit(resId);
+      }
     }
     return marker;
   }


### PR DESCRIPTION
## Summary
- resources added by markers are created as visible deposits
- remove a random hidden deposit of the same type to balance resource totals

## Testing
- `npm test` *(fails: 403 Forbidden - registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_6885e068a58c8324a430050d312535ef