### PR TITLE
Add tech scaling factor to state expansion

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,4 @@ _Inspiration:_
 
 ***Praesmeodymium added a resources layer and hooked it into civilization generation with some advantages during the growth, not fully tested for balance, or a lot of other things. Resource editor shows undiscovered/unused resources as well as an editor for placing/removing and custom resources. not all rescource data is exposed in the editor yet. ***
 - Certain markers like sacred forests now automatically spawn hidden resource deposits.
+- States gain a small expansion bonus from nearby resources via the new `tech_scaling` factor.

--- a/modules/burgs-and-states.js
+++ b/modules/burgs-and-states.js
@@ -7,6 +7,9 @@ window.BurgsAndStates = (() => {
     const {cells, cultures} = pack;
     const n = cells.i.length;
 
+    // tech_scaling defines how much a state's tech score affects its ability to expand
+    const tech_scaling = 0.025;
+
     function getResourcesAround(cellId, radius = 20 * grid.spacing) {
       const [x, y] = cells.p[cellId];
       const nearby = findAll(x, y, radius);
@@ -364,7 +367,8 @@ window.BurgsAndStates = (() => {
         const riverCost = getRiverCost(cells.r[e], e, type);
         const typeCost = getTypeCost(cells.t[e], type);
         const cellCost = Math.max(cultureCost + populationCost + biomeCost + heightCost + riverCost + typeCost, 0);
-        const totalCost = p + 10 + cellCost / states[s].expansionism;
+        const techMultiplier = 1 + states[s].tech * tech_scaling;
+        const totalCost = p + 10 + cellCost / (states[s].expansionism * techMultiplier);
 
         if (totalCost > growthRate) return;
 
@@ -460,7 +464,8 @@ window.BurgsAndStates = (() => {
         const riverCost = getRiverCost(cells.r[e], e, type);
         const typeCost = getTypeCost(cells.t[e], type);
         const cellCost = Math.max(cultureCost + populationCost + biomeCost + heightCost + riverCost + typeCost, 0);
-        const totalCost = p + 10 + cellCost / states[s].expansionism;
+        const techMultiplier = 1 + states[s].tech * tech_scaling;
+        const totalCost = p + 10 + cellCost / (states[s].expansionism * techMultiplier);
 
         if (totalCost > growthRate) return;
 


### PR DESCRIPTION
## Summary
- introduce `tech_scaling` constant to control how resources boost state tech
- apply the tech multiplier when calculating cell expansion costs
- document the new tech expansion bonus in README

## Testing
- `npm test` *(fails: 403 Forbidden when fetching npm packages)*

------
https://chatgpt.com/codex/tasks/task_e_68867a87cd30832489c3d98be9e3ccbe