### PR TITLE
Fix stale module caching

### DIFF
--- a/index.html
+++ b/index.html
@@ -8171,7 +8171,7 @@
     <script src="modules/biomes.js?v=1.99.00"></script>
     <script src="modules/names-generator.js?v=1.105.11"></script>
     <script src="modules/cultures-generator.js?v=1.106.0"></script>
-    <script src="modules/burgs-and-states.js?v=1.106.0"></script>
+    <script src="modules/burgs-and-states.js?v=1.108.11"></script>
     <script src="modules/provinces-generator.js?v=1.106.0"></script>
     <script src="modules/routes-generator.js?v=1.106.0"></script>
     <script src="modules/religions-generator.js?v=1.106.0"></script>

--- a/versioning.js
+++ b/versioning.js
@@ -22,7 +22,10 @@ if (parseMapVersion(VERSION) !== VERSION) alert("versioning.js: Invalid format o
   if (loadingScreenVersion) loadingScreenVersion.innerText = `v${VERSION}`;
 
   const storedVersion = localStorage.getItem("version");
-  if (compareVersions(storedVersion, VERSION, {major: true, minor: true, patch: false}).isOlder) {
+  // Clear outdated cached scripts on patch update
+  if (compareVersions(storedVersion, VERSION, {major: true, minor: true, patch: true}).isOlder && storedVersion) {
+    cleanupData();
+  } else if (compareVersions(storedVersion, VERSION, {major: true, minor: true, patch: false}).isOlder) {
     setTimeout(showUpdateWindow, 6000);
   }
 


### PR DESCRIPTION
## Summary
- bump query string for `burgs-and-states.js` so browsers load the patched module
- clear cached data automatically when the patch version changes

## Testing
- `npm test` *(fails: 403 Forbidden when fetching jest)*

------
https://chatgpt.com/codex/tasks/task_e_6888856f45e483249cbda540cdda1052