### PR TITLE
Fix civilization growth refresh logic

### DIFF
--- a/modules/burgs-and-states.js
+++ b/modules/burgs-and-states.js
@@ -28,7 +28,7 @@ window.BurgsAndStates = (() => {
     pack.states = createStates();
 
     placeTowns();
-    const steps = showGrowth ? expandStatesWithSteps() : (expandStates(), null);
+    const growthData = showGrowth ? expandStatesWithSteps() : (expandStates(), null);
     normalizeStates();
     getPoles();
 
@@ -40,7 +40,7 @@ window.BurgsAndStates = (() => {
     generateCampaigns();
     generateDiplomacy();
 
-    return {growthSteps: steps};
+    return {growthSteps: growthData};
 
     function placeCapitals() {
       TIME && console.time("placeCapitals");
@@ -430,6 +430,7 @@ window.BurgsAndStates = (() => {
     const queue = new FlatQueue();
     const cost = [];
     const steps = [];
+    let initialStates;
 
     const globalGrowthRate = byId("growthRate").valueAsNumber || 1;
     const statesGrowthRate = byId("statesGrowthRate")?.valueAsNumber || 1;
@@ -450,6 +451,8 @@ window.BurgsAndStates = (() => {
       queue.push({e: state.center, p: 0, s: state.i, b}, 0);
       cost[state.center] = 1;
     }
+
+    initialStates = new Uint16Array(cells.state);
 
     while (queue.length) {
       const next = queue.pop();
@@ -488,7 +491,7 @@ window.BurgsAndStates = (() => {
     burgs.filter(b => b.i && !b.removed).forEach(b => (b.state = cells.state[b.cell]));
 
     TIME && console.timeEnd("expandStatesWithSteps");
-    return steps;
+    return {steps, initialStates};
   };
 
   const normalizeStates = () => {

--- a/modules/ui/civ-player-controls.js
+++ b/modules/ui/civ-player-controls.js
@@ -6,6 +6,7 @@ window.CivPlayerControls = (() => {
   let timer = null;
   let playing = false;
   let counterEl = null;
+  let initialStates = null;
 
   function showLayer() {
     if (!layerIsOn('toggleStates')) toggleStates();
@@ -51,6 +52,11 @@ window.CivPlayerControls = (() => {
     pack.cells.state[step.cell] = forward ? step.to : step.from;
   }
 
+  function resetToInitial() {
+    if (initialStates) pack.cells.state.set(initialStates);
+    index = 0;
+  }
+
   function draw() {
     if (layerIsOn('toggleStates')) drawStates();
     updateCounter();
@@ -67,17 +73,20 @@ window.CivPlayerControls = (() => {
   }
 
   function start(growthSteps) {
-    steps = growthSteps || [];
-    index = 0;
+    if (growthSteps && growthSteps.steps) {
+      steps = growthSteps.steps;
+      initialStates = growthSteps.initialStates || null;
+    } else {
+      steps = growthSteps || [];
+      initialStates = null;
+    }
+    resetToInitial();
     draw();
   }
 
   function rewind() {
     pause();
-    while (index > 0) {
-      index--;
-      applyStep(index, false);
-    }
+    resetToInitial();
     draw();
   }
 
@@ -106,8 +115,10 @@ window.CivPlayerControls = (() => {
 
   function regenerate() {
     pause();
-    steps = BurgsAndStates.expandStatesWithSteps();
-    index = 0;
+    const data = BurgsAndStates.expandStatesWithSteps();
+    steps = data.steps;
+    initialStates = data.initialStates;
+    resetToInitial();
     draw();
     play();
   }

--- a/modules/ui/growth-show.js
+++ b/modules/ui/growth-show.js
@@ -4,6 +4,7 @@ window.GrowthShowUI = (() => {
   let steps = [];
   let index = 0;
   let timer = null;
+  let initialStates = null;
 
   const playBtn = byId("growthPlayBtn");
   const pauseBtn = byId("growthPauseBtn");
@@ -24,6 +25,11 @@ window.GrowthShowUI = (() => {
     const step = steps[i];
     if (!step) return;
     pack.cells.state[step.cell] = forward ? step.to : step.from;
+  }
+
+  function resetToInitial() {
+    if (initialStates) pack.cells.state.set(initialStates);
+    index = 0;
   }
 
   function draw() {
@@ -52,10 +58,7 @@ window.GrowthShowUI = (() => {
 
   function rewind() {
     pause();
-    while (index > 0) {
-      index--;
-      applyStep(index, false);
-    }
+    resetToInitial();
     draw();
   }
 
@@ -84,8 +87,10 @@ window.GrowthShowUI = (() => {
 
   function regenerate() {
     pause();
-    steps = BurgsAndStates.expandStatesWithSteps();
-    index = 0;
+    const data = BurgsAndStates.expandStatesWithSteps();
+    steps = data.steps;
+    initialStates = data.initialStates;
+    resetToInitial();
     draw();
     play();
   }
@@ -104,8 +109,14 @@ window.GrowthShowUI = (() => {
   }
 
   function start(growthSteps) {
-    steps = growthSteps || [];
-    index = 0;
+    if (growthSteps && growthSteps.steps) {
+      steps = growthSteps.steps;
+      initialStates = growthSteps.initialStates || null;
+    } else {
+      steps = growthSteps || [];
+      initialStates = null;
+    }
+    resetToInitial();
     draw();
     if (steps.length) play();
   }


### PR DESCRIPTION
## Summary
- return initial state data from `expandStatesWithSteps`
- reset state map to initial state when restarting civilization growth player
- keep animation controls in sync with new structure

## Testing
- `npm run lint`
- `npm test` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6888ac14bf9c8324a747c06adf0e9c23