### PR TITLE
Implement resource discovery timeline

### DIFF
--- a/main.js
+++ b/main.js
@@ -653,7 +653,7 @@ async function generate(options) {
     rankCells();
     Cultures.generate();
     Cultures.expand();
-    const {growthSteps} = BurgsAndStates.generate({showGrowth: byId("showGrowth")?.checked});
+    const {growthSteps, resourceSteps} = BurgsAndStates.generate({showGrowth: byId("showGrowth")?.checked});
     Resources.discoverAroundBurgs();
     Routes.generate();
     Religions.generate();
@@ -677,7 +677,8 @@ async function generate(options) {
     if (byId("showGrowth")?.checked) {
       // Growth steps computed above will be passed to CivPlayerControls
     }
-    CivPlayerControls.start(growthSteps);
+    const replayData = growthSteps ? {...growthSteps, resourceSteps} : {steps: [], initialStates: null, resourceSteps};
+    CivPlayerControls.start(replayData);
     INFO && console.groupEnd("Generated Map " + seed);
   } catch (error) {
     ERROR && console.error(error);

--- a/modules/burgs-and-states.js
+++ b/modules/burgs-and-states.js
@@ -29,6 +29,10 @@ window.BurgsAndStates = (() => {
 
     placeTowns();
     const growthData = showGrowth ? expandStatesWithSteps() : (expandStates(), null);
+    let resourceSteps = null;
+    if (showGrowth && growthData) {
+      resourceSteps = Resources.computeDiscoverySteps(growthData.steps, growthData.initialStates);
+    }
     normalizeStates();
     getPoles();
 
@@ -40,7 +44,7 @@ window.BurgsAndStates = (() => {
     generateCampaigns();
     generateDiplomacy();
 
-    return {growthSteps: growthData};
+    return {growthSteps: growthData, resourceSteps};
 
     function placeCapitals() {
       TIME && console.time("placeCapitals");

--- a/tests/markerResourceLink.test.js
+++ b/tests/markerResourceLink.test.js
@@ -32,4 +32,5 @@ test('adding marker with resource adds deposit', () => {
 
   expect(pack.resources.length).toBe(1);
   expect(pack.cells.hiddenResource[0]).toBe(13);
+  expect(pack.resources[0].discoveredStep).toBe(0);
 });


### PR DESCRIPTION
## Summary
- track discovery turn for each deposit
- compute discovery steps during state expansion
- extend player to show/hide resources as steps progress
- test resource deposits created from markers

## Testing
- `npm test` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6888b3c000988324b2e57847bc3fb4d0