### PR TITLE
Fix resource icon rendering and simplify layers

### DIFF
--- a/modules/renderers/draw-resources.js
+++ b/modules/renderers/draw-resources.js
@@ -8,50 +8,60 @@ function drawResources(showHidden = false) {
   const useIcons = Resources.getUseIcons();
   const tooltipSupported = !MOBILE && document.getElementById("tooltip");
 
-  const html = pack.resources
-    .filter(r => showHidden || r.visible)
-    .filter(r => Resources.isTypeVisible(r.type))
-    .map(r => {
-      const type = Resources.getType(r.type);
-      const color = type?.color || "#000";
-      const name = type?.name || "Unknown";
-      const tons = r.tons || 1;
-      const tipText = `${name}: ${tons.toLocaleString()} tons`;
+  const deposits = pack.resources.filter(r => Resources.isTypeVisible(r.type));
 
-      // radius should not depend on current zoom when redrawn
-      const radius = bySize ? getRenderRadius(tons, 1) : 3;
-      const labelSize = Math.max(radius * 1.5, 8);
+  const renderDeposit = r => {
+    const type = Resources.getType(r.type);
+    const color = type?.color || "#000";
+    const name = type?.name || "Unknown";
+    const tons = r.tons || 1;
+    const tipText = `${name}: ${tons.toLocaleString()} tons`;
 
-      if (bySize || !useIcons || !type?.icon) {
-        if (tooltipSupported)
-          return `<circle id="resource${r.i}" cx="${r.x}" cy="${r.y}" r="${radius}" fill="${color}" data-tip="${tipText}" />`;
-        return `<g id="resource${r.i}"><circle cx="${r.x}" cy="${r.y}" r="${radius}" fill="${color}" />` +
-               `<text x="${r.x}" y="${r.y}" font-size="${labelSize}px" dominant-baseline="central" text-anchor="middle">${si(tons)}</text></g>`;
-      }
+    // radius should not depend on current zoom when redrawn
+    const radius = bySize ? getRenderRadius(tons, 1) : 3;
+    const labelSize = Math.max(radius * 1.5, 8);
 
-      const icon = type.icon;
-      const px = type.px || 12;
-      const viewX = rn(r.x - px / 2, 1);
-      const viewY = rn(r.y - px / 2, 1);
-      const isExternal = icon.startsWith("http") || icon.startsWith("data:image");
-
+    if (bySize || !useIcons || !type?.icon) {
       if (tooltipSupported)
-        return `\
-<svg id="resource${r.i}" width="${px}" height="${px}" x="${viewX}" y="${viewY}" viewBox="0 0 ${px} ${px}" data-tip="${tipText}">
+        return `<circle id="resource${r.i}" cx="${r.x}" cy="${r.y}" r="${radius}" fill="${color}" data-tip="${tipText}" />`;
+      return `<g id="resource${r.i}"><circle cx="${r.x}" cy="${r.y}" r="${radius}" fill="${color}" />` +
+             `<text x="${r.x}" y="${r.y}" font-size="${labelSize}px" dominant-baseline="central" text-anchor="middle">${si(tons)}</text></g>`;
+    }
+
+    const icon = type.icon;
+    const px = type.px || 12;
+    const visualLen = Array.from(icon.replace(/\uFE0F/g, "")).length || 1;
+    const width = px * visualLen;
+    const viewX = rn(r.x - width / 2, 1);
+    const viewY = rn(r.y - px / 2, 1);
+    const isExternal = icon.startsWith("http") || icon.startsWith("data:image");
+
+    if (tooltipSupported)
+      return `\
+<svg id="resource${r.i}" width="${width}" height="${px}" x="${viewX}" y="${viewY}" viewBox="0 0 ${width} ${px}" data-tip="${tipText}">
   <text x="50%" y="50%" font-size="${px}px" dominant-baseline="central" text-anchor="middle">${isExternal ? "" : icon}</text>
-  <image x="0" y="0" width="${px}" height="${px}" href="${isExternal ? icon : ""}" />
+  <image x="0" y="0" width="${width}" height="${px}" href="${isExternal ? icon : ""}" />
 </svg>`;
 
-      return `\
+    return `\
 <g id="resource${r.i}">
-  <svg width="${px}" height="${px}" x="${viewX}" y="${viewY}" viewBox="0 0 ${px} ${px}">
+  <svg width="${width}" height="${px}" x="${viewX}" y="${viewY}" viewBox="0 0 ${width} ${px}">
     <text x="50%" y="50%" font-size="${px}px" dominant-baseline="central" text-anchor="middle">${isExternal ? "" : icon}</text>
-    <image x="0" y="0" width="${px}" height="${px}" href="${isExternal ? icon : ""}" />
+    <image x="0" y="0" width="${width}" height="${px}" href="${isExternal ? icon : ""}" />
   </svg>
   <text x="${r.x}" y="${r.y}" font-size="${labelSize}px" dominant-baseline="central" text-anchor="middle">${si(tons)}</text>
 </g>`;
-    });
+  };
 
-  resources.html(html.join(""));
+  if (showHidden) {
+    const all = deposits.map(renderDeposit).join("");
+    resources.append("g").attr("id", "resources-all").html(all);
+    const discovered = deposits.filter(r => r.visible).map(renderDeposit).join("");
+    resources.append("g").attr("id", "resources-discovered").html(discovered);
+  } else {
+    const discovered = deposits.filter(r => r.visible).map(renderDeposit).join("");
+    resources.append("g").attr("id", "resources-discovered").html(discovered);
+  }
+
   TIME && console.timeEnd("drawResources");
 }


### PR DESCRIPTION
## Summary
- handle multi-character emoji icons by adjusting width
- render resources into two sublayers so discovered and hidden deposits display correctly together

## Testing
- `npm test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jest)*

------
https://chatgpt.com/codex/tasks/task_e_6889c2d86aa083248c612c5e8a12909c